### PR TITLE
fix: Images are not displayed correctly in the exported markdown docu…

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -196,11 +196,8 @@ export async function tryCopyMarkdownByRead(
 				const imageLink = imageLinks[index][1];
 				const imageLinkMd5 = md5(imageLink);
 				const imageExt = path.extname(imageLink);
-
-				const hashLink = path.join(
-					plugin.settings.attachment,
-					imageLinkMd5.concat(imageExt)
-				);
+				// Unify the link separator in obsidian as a forward slash instead of the default back slash in windows, so that the referenced images can be displayed properly
+				const hashLink = path.join(plugin.settings.attachment, imageLinkMd5.concat(imageExt)).replace('\\','/');
 
 				if (plugin.settings.GTM) {
 					content = content.replace(


### PR DESCRIPTION
completed content : 
fix: Images are not displayed correctly in the exported markdown document due to the path separator problems on windows systems

## Question

To export markdown and its attachments to 'output' folder with your plugin on windows system. when open the exported markdown , the image attachment cannot display correctly due to the path separator problems on windows systems. the shot as following 

![image](https://user-images.githubusercontent.com/55736512/217510620-de34518a-a871-43a0-9966-44eda5849970.png)

the path seperator is backslash ( \ ) that cause image cannot display correctly

whereas when you modify \ to / manually, the image can display again ! 

The reason i guess is the default path seperator difference between linux,macOS and windows. 

on macOS ( you are using ) is  /  
on windows is  \ 

you can see [here ](https://en.wikipedia.org/wiki/Path_%28computing%29#Representations_of_paths_by_operating_system_and_shell) for more details.

**The key to display the image correctly is the path separator that must be '/'  slash, In particular on obsidian editor.** 
if you have used other markdown editors like Typora, both '/' and  '\\'   , the image can display correctly.


## My solution 

i have read your code in `utils.ts`, founding this line [#L200](https://github.com/bingryan/obsidian-markdown-export-plugin/blob/0e2733117fa89857386b60d817ee4c01fa5d139c/src/utils.ts#L200)  seems to  have problem.

`const hashLink = path.join(plugin.settings.attachment,imageLinkMd5.concat(imageExt));`  

for **hashLink** , on macOS the path seperator is /  while \ on windows , so i  made  change to 

`const hashLink = path.join(plugin.settings.attachment, imageLinkMd5.concat(imageExt)).replace('\\','/');`

`replace('\\','/');` is only work on windows 


---
 this is my first experience to contribute on GitHub, I'm not too sure about the github pull request rules and specifications, if there is something wrong, please give me suggestions, thanks!

