### PR TITLE
feat: Add a option to keep attachment file name unchanged or use md5 of file name to rename(#68)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -11,10 +11,12 @@ export interface MarkdownExportPluginSettings {
 	output: string;
 	attachment: string;
 	GFM: boolean;
+	KeepOriginName: boolean;
 }
 
 export const DEFAULT_SETTINGS: MarkdownExportPluginSettings = {
 	output: "output",
 	attachment: "attachment",
 	GFM: true,
+	KeepOriginName: false,
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -162,5 +162,19 @@ class MarkdownExportSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
+
+		new Setting(containerEl)
+			.setName("Keep attchments file name")
+			.setDesc(
+				"Keep attchments file name"
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.KeepOriginName)
+					.onChange(async (value: boolean) => {
+						this.plugin.settings.KeepOriginName = value;
+						await this.plugin.saveSettings();
+					})
+			);
 	}
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -216,8 +216,16 @@ export async function tryCopyImage(
 						imageLink = imageLink.split("|")[0];
 					}
 
-					const imageLinkMd5 = md5(imageLink);
-					const imageExt = path.extname(imageLink);
+					var imageLinkMd5;
+					if (plugin.settings.KeepOriginName){
+						imageLinkMd5 = imageLink.split("/")[1];
+					} else {
+						const imageExt = path.extname(imageLink);
+						imageLinkMd5 = md5(imageLink).concat(imageExt);
+					}
+					
+					console.log(imageLink);
+					
 					const ifile = plugin.app.metadataCache.getFirstLinkpathDest(
 						imageLink,
 						contentPath
@@ -237,7 +245,7 @@ export async function tryCopyImage(
 						.join(
 							plugin.settings.output,
 							plugin.settings.attachment,
-							imageLinkMd5.concat(imageExt)
+							imageLinkMd5
 						)
 						.replace(/\\/g, "/");
 
@@ -345,8 +353,14 @@ export async function tryCopyMarkdownByRead(
 				if (imageLink.contains("|")) {
 					imageLink = imageLink.split("|")[0];
 				}
-				const imageLinkMd5 = md5(imageLink);
-				const imageExt = path.extname(imageLink);
+
+				var imageLinkMd5;
+				if (plugin.settings.KeepOriginName){
+					imageLinkMd5 = encodeURI(imageLink.split("/")[1]);
+				} else {
+					const imageExt = path.extname(imageLink);
+					imageLinkMd5 = md5(imageLink).concat(imageExt);
+				}
 				// Unify the link separator in obsidian as a forward slash instead of the default back slash in windows, so that the referenced images can be displayed properly
 
 				const clickSubRoute = getClickSubRoute(outputSubPath);
@@ -355,7 +369,7 @@ export async function tryCopyMarkdownByRead(
 					.join(
 						clickSubRoute,
 						plugin.settings.attachment,
-						imageLinkMd5.concat(imageExt)
+						imageLinkMd5
 					)
 					.replace(/\\/g, "/");
 


### PR DESCRIPTION
Add a option to keep attachment file name unchanged or use md5 of file name to rename(#68)
Using the latest master branch
