### PR TITLE
feat: add displayImageAsHtml and removeOutgoingLinkBrackets options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-markdown-export",
-	"version": "1.0.1",
+	"version": "1.0.18",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-markdown-export",
-			"version": "1.0.1",
+			"version": "1.0.18",
 			"license": "MIT",
 			"dependencies": {
 				"md5": "^2.3.0"
@@ -14,12 +14,13 @@
 			"devDependencies": {
 				"@types/md5": "^2.3.2",
 				"@types/node": "^16.11.6",
-				"@typescript-eslint/eslint-plugin": "5.29.0",
-				"@typescript-eslint/parser": "5.29.0",
-				"auto": "^10.37.6",
-				"auto-plugin-obsidian": "^0.1.4",
+				"@typescript-eslint/eslint-plugin": "^5.47.0",
+				"@typescript-eslint/parser": "^5.47.0",
+				"auto": "^11.0.7",
+				"auto-plugin-obsidian": "^0.1.6",
 				"builtin-modules": "3.3.0",
 				"esbuild": "0.14.47",
+				"eslint": "^8.30.0",
 				"obsidian": "latest",
 				"tslib": "2.4.0",
 				"typescript": "4.7.4"
@@ -103,13 +104,13 @@
 			}
 		},
 		"node_modules/@auto-it/npm": {
-			"version": "10.37.6",
-			"resolved": "https://registry.npmmirror.com/@auto-it/npm/-/npm-10.37.6.tgz",
-			"integrity": "sha512-18CpaX3YfpJ6vwONYEBy9ORiPGplrtQ30pzRtDpKZzHin5wakdOyPd1P5lWeZBmCQCyiszdRteeQsXzFbaSuoQ==",
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@auto-it/npm/-/npm-11.1.6.tgz",
+			"integrity": "sha512-eFWzR+6N1lMSXi32BunnlIdXIFikX6mieaFLmPk9VNM4vOXqsfkc7BQ0xhsZRsn5sxSR/XBwlQXoExAHybjs3g==",
 			"dev": true,
 			"dependencies": {
-				"@auto-it/core": "10.37.6",
-				"@auto-it/package-json-utils": "10.37.6",
+				"@auto-it/core": "11.1.6",
+				"@auto-it/package-json-utils": "11.1.6",
 				"await-to-js": "^3.0.0",
 				"endent": "^2.1.0",
 				"env-ci": "^5.0.1",
@@ -124,16 +125,93 @@
 				"user-home": "^2.0.0"
 			}
 		},
+		"node_modules/@auto-it/npm/node_modules/@auto-it/bot-list": {
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@auto-it/bot-list/-/bot-list-11.1.6.tgz",
+			"integrity": "sha512-3Qdphiw9JlzYX15moLZSaP+jNuM3UAFDHTgIpsfnfIQwQDNSjZhM4rwxqsAY/r1mJAyxt16c6wbqisi7KNFD/A==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.x"
+			}
+		},
+		"node_modules/@auto-it/npm/node_modules/@auto-it/core": {
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@auto-it/core/-/core-11.1.6.tgz",
+			"integrity": "sha512-bxiUXJVyRYs7Bf4DH/JLT5pdR14RYSpoX0eBw0ilkU9qNqylTCbThuKofM7Bqn7jaQF2PDUoC72c8xCkqvHGQg==",
+			"dev": true,
+			"dependencies": {
+				"@auto-it/bot-list": "11.1.6",
+				"@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
+				"@octokit/core": "^3.5.1",
+				"@octokit/plugin-enterprise-compatibility": "1.3.0",
+				"@octokit/plugin-retry": "^3.0.9",
+				"@octokit/plugin-throttling": "^3.6.2",
+				"@octokit/rest": "^18.12.0",
+				"await-to-js": "^3.0.0",
+				"chalk": "^4.0.0",
+				"cosmiconfig": "7.0.0",
+				"deepmerge": "^4.0.0",
+				"dotenv": "^8.0.0",
+				"endent": "^2.1.0",
+				"enquirer": "^2.3.4",
+				"env-ci": "^5.0.1",
+				"fast-glob": "^3.1.1",
+				"fp-ts": "^2.5.3",
+				"fromentries": "^1.2.0",
+				"gitlog": "^4.0.3",
+				"https-proxy-agent": "^5.0.0",
+				"import-cwd": "^3.0.0",
+				"import-from": "^3.0.0",
+				"io-ts": "^2.1.2",
+				"lodash.chunk": "^4.2.0",
+				"log-symbols": "^4.0.0",
+				"node-fetch": "2.6.7",
+				"parse-author": "^2.0.0",
+				"parse-github-url": "1.0.2",
+				"pretty-ms": "^7.0.0",
+				"requireg": "^0.2.2",
+				"semver": "^7.0.0",
+				"signale": "^1.4.0",
+				"tapable": "^2.2.0",
+				"terminal-link": "^2.1.1",
+				"tinycolor2": "^1.4.1",
+				"ts-node": "^10.9.1",
+				"tslib": "2.1.0",
+				"type-fest": "^0.21.1",
+				"typescript-memoize": "^1.0.0-alpha.3",
+				"url-join": "^4.0.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.7"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@auto-it/npm/node_modules/tslib": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
 			"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
 			"dev": true
 		},
+		"node_modules/@auto-it/npm/node_modules/type-fest": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@auto-it/package-json-utils": {
-			"version": "10.37.6",
-			"resolved": "https://registry.npmmirror.com/@auto-it/package-json-utils/-/package-json-utils-10.37.6.tgz",
-			"integrity": "sha512-rUoEcEnPgHG8X/XkPe3PKFHhXD3AsplXB0Rpr7lJQta5XzDqmWzc/xVL1vMmM4IpXMI5lK7A9OZosWjgJVI7jA==",
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@auto-it/package-json-utils/-/package-json-utils-11.1.6.tgz",
+			"integrity": "sha512-RSXmO+KegaEY7uw1vt8iXL9FShiinFigKNFuIWM9oLSaSHJfeQ2ZD291i9nV+tz86bPGySBb5ktdJ3uo2pAZ+Q==",
 			"dev": true,
 			"dependencies": {
 				"parse-author": "^2.0.0",
@@ -144,24 +222,101 @@
 			}
 		},
 		"node_modules/@auto-it/released": {
-			"version": "10.37.6",
-			"resolved": "https://registry.npmmirror.com/@auto-it/released/-/released-10.37.6.tgz",
-			"integrity": "sha512-988nCdYApyzKwZx6W6lHNHS9aEw9xLFbfDcTWrSKUOChjT8yDcGadDDXVhj3M0uhHojr8jXKbrRATEPyEeTDlg==",
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@auto-it/released/-/released-11.1.6.tgz",
+			"integrity": "sha512-RHTSjq5fAQxkhcC84aWItotyPGH67o+bzSxzr9H4mzvP8OrIxj7Jsfmk8wT4rjgupCTl9fu8DiGoCGjcQpCdCw==",
 			"dev": true,
 			"dependencies": {
-				"@auto-it/bot-list": "10.37.6",
-				"@auto-it/core": "10.37.6",
+				"@auto-it/bot-list": "11.1.6",
+				"@auto-it/core": "11.1.6",
 				"deepmerge": "^4.0.0",
 				"fp-ts": "^2.5.3",
 				"io-ts": "^2.1.2",
 				"tslib": "2.1.0"
 			}
 		},
+		"node_modules/@auto-it/released/node_modules/@auto-it/bot-list": {
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@auto-it/bot-list/-/bot-list-11.1.6.tgz",
+			"integrity": "sha512-3Qdphiw9JlzYX15moLZSaP+jNuM3UAFDHTgIpsfnfIQwQDNSjZhM4rwxqsAY/r1mJAyxt16c6wbqisi7KNFD/A==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.x"
+			}
+		},
+		"node_modules/@auto-it/released/node_modules/@auto-it/core": {
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@auto-it/core/-/core-11.1.6.tgz",
+			"integrity": "sha512-bxiUXJVyRYs7Bf4DH/JLT5pdR14RYSpoX0eBw0ilkU9qNqylTCbThuKofM7Bqn7jaQF2PDUoC72c8xCkqvHGQg==",
+			"dev": true,
+			"dependencies": {
+				"@auto-it/bot-list": "11.1.6",
+				"@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
+				"@octokit/core": "^3.5.1",
+				"@octokit/plugin-enterprise-compatibility": "1.3.0",
+				"@octokit/plugin-retry": "^3.0.9",
+				"@octokit/plugin-throttling": "^3.6.2",
+				"@octokit/rest": "^18.12.0",
+				"await-to-js": "^3.0.0",
+				"chalk": "^4.0.0",
+				"cosmiconfig": "7.0.0",
+				"deepmerge": "^4.0.0",
+				"dotenv": "^8.0.0",
+				"endent": "^2.1.0",
+				"enquirer": "^2.3.4",
+				"env-ci": "^5.0.1",
+				"fast-glob": "^3.1.1",
+				"fp-ts": "^2.5.3",
+				"fromentries": "^1.2.0",
+				"gitlog": "^4.0.3",
+				"https-proxy-agent": "^5.0.0",
+				"import-cwd": "^3.0.0",
+				"import-from": "^3.0.0",
+				"io-ts": "^2.1.2",
+				"lodash.chunk": "^4.2.0",
+				"log-symbols": "^4.0.0",
+				"node-fetch": "2.6.7",
+				"parse-author": "^2.0.0",
+				"parse-github-url": "1.0.2",
+				"pretty-ms": "^7.0.0",
+				"requireg": "^0.2.2",
+				"semver": "^7.0.0",
+				"signale": "^1.4.0",
+				"tapable": "^2.2.0",
+				"terminal-link": "^2.1.1",
+				"tinycolor2": "^1.4.1",
+				"ts-node": "^10.9.1",
+				"tslib": "2.1.0",
+				"type-fest": "^0.21.1",
+				"typescript-memoize": "^1.0.0-alpha.3",
+				"url-join": "^4.0.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.7"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@auto-it/released/node_modules/tslib": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
 			"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
 			"dev": true
+		},
+		"node_modules/@auto-it/released/node_modules/type-fest": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/@auto-it/upload-assets": {
 			"version": "10.37.6",
@@ -186,23 +341,106 @@
 			"dev": true
 		},
 		"node_modules/@auto-it/version-file": {
-			"version": "10.37.6",
-			"resolved": "https://registry.npmmirror.com/@auto-it/version-file/-/version-file-10.37.6.tgz",
-			"integrity": "sha512-BO7f1bWrUFkhp7RwwmkegBUc/VwJrIlQQaFm7l/cc5IGZ7DL0rPap8UbytSL3aWV9YzoZpqgWNj2KPRGvwguag==",
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@auto-it/version-file/-/version-file-11.1.6.tgz",
+			"integrity": "sha512-iDAK0IrCYFPDgkX4DGB97VFbiFEfxN+IMW1NiF+Qk7Kd3SX2899vwuFxyVvGwovX7ssuCi/4tSTrvx6PLhH6zw==",
 			"dev": true,
 			"dependencies": {
-				"@auto-it/core": "10.37.6",
+				"@auto-it/core": "11.1.6",
 				"fp-ts": "^2.5.3",
 				"io-ts": "^2.1.2",
 				"semver": "^7.0.0",
 				"tslib": "1.10.0"
 			}
 		},
+		"node_modules/@auto-it/version-file/node_modules/@auto-it/bot-list": {
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@auto-it/bot-list/-/bot-list-11.1.6.tgz",
+			"integrity": "sha512-3Qdphiw9JlzYX15moLZSaP+jNuM3UAFDHTgIpsfnfIQwQDNSjZhM4rwxqsAY/r1mJAyxt16c6wbqisi7KNFD/A==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.x"
+			}
+		},
+		"node_modules/@auto-it/version-file/node_modules/@auto-it/core": {
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@auto-it/core/-/core-11.1.6.tgz",
+			"integrity": "sha512-bxiUXJVyRYs7Bf4DH/JLT5pdR14RYSpoX0eBw0ilkU9qNqylTCbThuKofM7Bqn7jaQF2PDUoC72c8xCkqvHGQg==",
+			"dev": true,
+			"dependencies": {
+				"@auto-it/bot-list": "11.1.6",
+				"@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
+				"@octokit/core": "^3.5.1",
+				"@octokit/plugin-enterprise-compatibility": "1.3.0",
+				"@octokit/plugin-retry": "^3.0.9",
+				"@octokit/plugin-throttling": "^3.6.2",
+				"@octokit/rest": "^18.12.0",
+				"await-to-js": "^3.0.0",
+				"chalk": "^4.0.0",
+				"cosmiconfig": "7.0.0",
+				"deepmerge": "^4.0.0",
+				"dotenv": "^8.0.0",
+				"endent": "^2.1.0",
+				"enquirer": "^2.3.4",
+				"env-ci": "^5.0.1",
+				"fast-glob": "^3.1.1",
+				"fp-ts": "^2.5.3",
+				"fromentries": "^1.2.0",
+				"gitlog": "^4.0.3",
+				"https-proxy-agent": "^5.0.0",
+				"import-cwd": "^3.0.0",
+				"import-from": "^3.0.0",
+				"io-ts": "^2.1.2",
+				"lodash.chunk": "^4.2.0",
+				"log-symbols": "^4.0.0",
+				"node-fetch": "2.6.7",
+				"parse-author": "^2.0.0",
+				"parse-github-url": "1.0.2",
+				"pretty-ms": "^7.0.0",
+				"requireg": "^0.2.2",
+				"semver": "^7.0.0",
+				"signale": "^1.4.0",
+				"tapable": "^2.2.0",
+				"terminal-link": "^2.1.1",
+				"tinycolor2": "^1.4.1",
+				"ts-node": "^10.9.1",
+				"tslib": "2.1.0",
+				"type-fest": "^0.21.1",
+				"typescript-memoize": "^1.0.0-alpha.3",
+				"url-join": "^4.0.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.7"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@auto-it/version-file/node_modules/@auto-it/core/node_modules/tslib": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+			"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+			"dev": true
+		},
 		"node_modules/@auto-it/version-file/node_modules/tslib": {
 			"version": "1.10.0",
-			"resolved": "https://registry.npmmirror.com/tslib/-/tslib-1.10.0.tgz",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
 			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
 			"dev": true
+		},
+		"node_modules/@auto-it/version-file/node_modules/type-fest": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.18.6",
@@ -385,17 +623,40 @@
 				"typescript": ">=2.7"
 			}
 		},
-		"node_modules/@eslint/eslintrc": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmmirror.com/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-			"integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+		"node_modules/@eslint-community/eslint-utils": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
 			"dev": true,
-			"peer": true,
+			"dependencies": {
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+			}
+		},
+		"node_modules/@eslint-community/regexpp": {
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
+			"integrity": "sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@eslint/eslintrc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.4.0",
-				"globals": "^13.15.0",
+				"espree": "^9.6.0",
+				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
@@ -404,17 +665,28 @@
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint/js": {
+			"version": "8.57.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.7",
-			"resolved": "https://registry.npmmirror.com/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-			"integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
+			"version": "0.11.14",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^1.2.1",
-				"debug": "^4.1.1",
+				"@humanwhocodes/object-schema": "^2.0.2",
+				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
 			},
 			"engines": {
@@ -426,17 +698,15 @@
 			"resolved": "https://registry.npmmirror.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=12.22"
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmmirror.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-			"dev": true,
-			"peer": true
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+			"dev": true
 		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.0",
@@ -726,11 +996,10 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {
-			"version": "7.0.11",
-			"resolved": "https://registry.npmmirror.com/@types/json-schema/-/json-schema-7.0.11.tgz",
-			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-			"dev": true,
-			"license": "MIT"
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"dev": true
 		},
 		"node_modules/@types/md5": {
 			"version": "2.3.2",
@@ -751,6 +1020,12 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
 			"dev": true
 		},
+		"node_modules/@types/semver": {
+			"version": "7.5.8",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+			"integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+			"dev": true
+		},
 		"node_modules/@types/tern": {
 			"version": "0.23.4",
 			"resolved": "https://registry.npmmirror.com/@types/tern/-/tern-0.23.4.tgz",
@@ -762,19 +1037,19 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.29.0.tgz",
-			"integrity": "sha512-kgTsISt9pM53yRFQmLZ4npj99yGl3x3Pl7z4eA66OuTzAGC4bQB5H5fuLwPnqTKU3yyrrg4MIhjF17UYnL4c0w==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+			"integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.29.0",
-				"@typescript-eslint/type-utils": "5.29.0",
-				"@typescript-eslint/utils": "5.29.0",
+				"@eslint-community/regexpp": "^4.4.0",
+				"@typescript-eslint/scope-manager": "5.62.0",
+				"@typescript-eslint/type-utils": "5.62.0",
+				"@typescript-eslint/utils": "5.62.0",
 				"debug": "^4.3.4",
-				"functional-red-black-tree": "^1.0.1",
+				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
-				"regexpp": "^3.2.0",
+				"natural-compare-lite": "^1.4.0",
 				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
 			},
@@ -796,15 +1071,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/parser/-/parser-5.29.0.tgz",
-			"integrity": "sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+			"integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
 			"dev": true,
-			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.29.0",
-				"@typescript-eslint/types": "5.29.0",
-				"@typescript-eslint/typescript-estree": "5.29.0",
+				"@typescript-eslint/scope-manager": "5.62.0",
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/typescript-estree": "5.62.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -824,14 +1098,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz",
-			"integrity": "sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+			"integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "5.29.0",
-				"@typescript-eslint/visitor-keys": "5.29.0"
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/visitor-keys": "5.62.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -842,13 +1115,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/type-utils/-/type-utils-5.29.0.tgz",
-			"integrity": "sha512-JK6bAaaiJozbox3K220VRfCzLa9n0ib/J+FHIwnaV3Enw/TO267qe0pM1b1QrrEuy6xun374XEAsRlA86JJnyg==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+			"integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/utils": "5.29.0",
+				"@typescript-eslint/typescript-estree": "5.62.0",
+				"@typescript-eslint/utils": "5.62.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			},
@@ -869,11 +1142,10 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/types/-/types-5.29.0.tgz",
-			"integrity": "sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+			"integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
@@ -883,14 +1155,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz",
-			"integrity": "sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+			"integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
 			"dev": true,
-			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@typescript-eslint/types": "5.29.0",
-				"@typescript-eslint/visitor-keys": "5.29.0",
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/visitor-keys": "5.62.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -911,18 +1182,19 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/utils/-/utils-5.29.0.tgz",
-			"integrity": "sha512-3Eos6uP1nyLOBayc/VUdKZikV90HahXE5Dx9L5YlSd/7ylQPXhLk1BYb29SDgnBnTp+jmSZUU0QxUiyHgW4p7A==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+			"integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.2.0",
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.29.0",
-				"@typescript-eslint/types": "5.29.0",
-				"@typescript-eslint/typescript-estree": "5.29.0",
+				"@types/semver": "^7.3.12",
+				"@typescript-eslint/scope-manager": "5.62.0",
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/typescript-estree": "5.62.0",
 				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0"
+				"semver": "^7.3.7"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -936,13 +1208,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz",
-			"integrity": "sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+			"integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "5.29.0",
+				"@typescript-eslint/types": "5.62.0",
 				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
@@ -953,20 +1224,16 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+			"dev": true
 		},
 		"node_modules/acorn": {
-			"version": "8.8.1",
-			"resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.8.1.tgz",
-			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+			"version": "8.11.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -977,10 +1244,9 @@
 		},
 		"node_modules/acorn-jsx": {
 			"version": "5.3.2",
-			"resolved": "https://registry.npmmirror.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
-			"peer": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
@@ -1008,15 +1274,18 @@
 		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
-			"resolved": "https://registry.npmmirror.com/ajv/-/ajv-6.12.6.tgz",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
 		"node_modules/ansi-colors": {
@@ -1054,7 +1323,6 @@
 			"resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1079,10 +1347,9 @@
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmmirror.com/argparse/-/argparse-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/array-back": {
 			"version": "3.1.0",
@@ -1095,17 +1362,16 @@
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmmirror.com/array-union/-/array-union-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/array-uniq": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmmirror.com/array-uniq/-/array-uniq-1.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
 			"integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
 			"dev": true,
 			"engines": {
@@ -1122,15 +1388,15 @@
 			}
 		},
 		"node_modules/auto": {
-			"version": "10.37.6",
-			"resolved": "https://registry.npmmirror.com/auto/-/auto-10.37.6.tgz",
-			"integrity": "sha512-zMLsXz/WPqSlNVlY6g1GlFyhow+x//htR2QwWYSxB4DvAFNggXnK6aRqJ1DrcjhtUAPL2ngw5hHHrCgHvyvAaw==",
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/auto/-/auto-11.1.6.tgz",
+			"integrity": "sha512-GKeZbFWPp7V9d+yWuFvaffVNyLSGFpR/+SrzXt29YKhg8axx5bKQKzbBN0eSzX5DLmhBwS81tWXS+SYpECil9Q==",
 			"dev": true,
 			"dependencies": {
-				"@auto-it/core": "10.37.6",
-				"@auto-it/npm": "10.37.6",
-				"@auto-it/released": "10.37.6",
-				"@auto-it/version-file": "10.37.6",
+				"@auto-it/core": "11.1.6",
+				"@auto-it/npm": "11.1.6",
+				"@auto-it/released": "11.1.6",
+				"@auto-it/version-file": "11.1.6",
 				"await-to-js": "^3.0.0",
 				"chalk": "^4.0.0",
 				"command-line-application": "^0.10.1",
@@ -1148,9 +1414,9 @@
 			}
 		},
 		"node_modules/auto-plugin-obsidian": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmmirror.com/auto-plugin-obsidian/-/auto-plugin-obsidian-0.1.4.tgz",
-			"integrity": "sha512-g6Ee9j+0HgphKpKfSmVhqcDT+ITxxXmMAcGWawyJnNcUIQ5ZwFcidN6RcuI9DN2bUCtFTHLuFTIprne+ZGbJdw==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/auto-plugin-obsidian/-/auto-plugin-obsidian-0.1.6.tgz",
+			"integrity": "sha512-d/aROWf81wFSo9QSPjdVFMv3yJWRCJphnnWu8X86lGITDTwwni3vk/5LjP9brtHTesFLMm5lFeEjWu7+n4vZ0A==",
 			"dev": true,
 			"dependencies": {
 				"@auto-it/core": "^10.16.5",
@@ -1161,11 +1427,88 @@
 				"semver": "^7.3.4"
 			}
 		},
+		"node_modules/auto/node_modules/@auto-it/bot-list": {
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@auto-it/bot-list/-/bot-list-11.1.6.tgz",
+			"integrity": "sha512-3Qdphiw9JlzYX15moLZSaP+jNuM3UAFDHTgIpsfnfIQwQDNSjZhM4rwxqsAY/r1mJAyxt16c6wbqisi7KNFD/A==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.x"
+			}
+		},
+		"node_modules/auto/node_modules/@auto-it/core": {
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@auto-it/core/-/core-11.1.6.tgz",
+			"integrity": "sha512-bxiUXJVyRYs7Bf4DH/JLT5pdR14RYSpoX0eBw0ilkU9qNqylTCbThuKofM7Bqn7jaQF2PDUoC72c8xCkqvHGQg==",
+			"dev": true,
+			"dependencies": {
+				"@auto-it/bot-list": "11.1.6",
+				"@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
+				"@octokit/core": "^3.5.1",
+				"@octokit/plugin-enterprise-compatibility": "1.3.0",
+				"@octokit/plugin-retry": "^3.0.9",
+				"@octokit/plugin-throttling": "^3.6.2",
+				"@octokit/rest": "^18.12.0",
+				"await-to-js": "^3.0.0",
+				"chalk": "^4.0.0",
+				"cosmiconfig": "7.0.0",
+				"deepmerge": "^4.0.0",
+				"dotenv": "^8.0.0",
+				"endent": "^2.1.0",
+				"enquirer": "^2.3.4",
+				"env-ci": "^5.0.1",
+				"fast-glob": "^3.1.1",
+				"fp-ts": "^2.5.3",
+				"fromentries": "^1.2.0",
+				"gitlog": "^4.0.3",
+				"https-proxy-agent": "^5.0.0",
+				"import-cwd": "^3.0.0",
+				"import-from": "^3.0.0",
+				"io-ts": "^2.1.2",
+				"lodash.chunk": "^4.2.0",
+				"log-symbols": "^4.0.0",
+				"node-fetch": "2.6.7",
+				"parse-author": "^2.0.0",
+				"parse-github-url": "1.0.2",
+				"pretty-ms": "^7.0.0",
+				"requireg": "^0.2.2",
+				"semver": "^7.0.0",
+				"signale": "^1.4.0",
+				"tapable": "^2.2.0",
+				"terminal-link": "^2.1.1",
+				"tinycolor2": "^1.4.1",
+				"ts-node": "^10.9.1",
+				"tslib": "2.1.0",
+				"type-fest": "^0.21.1",
+				"typescript-memoize": "^1.0.0-alpha.3",
+				"url-join": "^4.0.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.7"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/auto/node_modules/tslib": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.1.0.tgz",
 			"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
 			"dev": true
+		},
+		"node_modules/auto/node_modules/type-fest": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/await-to-js": {
 			"version": "3.0.0",
@@ -1584,10 +1927,9 @@
 		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
-			"resolved": "https://registry.npmmirror.com/deep-is/-/deep-is-0.1.4.tgz",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/deepmerge": {
 			"version": "4.2.2",
@@ -1615,10 +1957,9 @@
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmmirror.com/dir-glob/-/dir-glob-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"path-type": "^4.0.0"
 			},
@@ -1631,7 +1972,6 @@
 			"resolved": "https://registry.npmmirror.com/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"esutils": "^2.0.2"
 			},
@@ -1752,56 +2092,53 @@
 			"resolved": "https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.27.0",
-			"resolved": "https://registry.npmmirror.com/eslint/-/eslint-8.27.0.tgz",
-			"integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
+			"version": "8.57.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+			"integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
-				"@eslint/eslintrc": "^1.3.3",
-				"@humanwhocodes/config-array": "^0.11.6",
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.6.1",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.57.0",
+				"@humanwhocodes/config-array": "^0.11.14",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
-				"ajv": "^6.10.0",
+				"@ungap/structured-clone": "^1.2.0",
+				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
 				"debug": "^4.3.2",
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.1.1",
-				"eslint-utils": "^3.0.0",
-				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.4.0",
-				"esquery": "^1.4.0",
+				"eslint-scope": "^7.2.2",
+				"eslint-visitor-keys": "^3.4.3",
+				"espree": "^9.6.1",
+				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
 				"glob-parent": "^6.0.2",
-				"globals": "^13.15.0",
-				"grapheme-splitter": "^1.0.4",
+				"globals": "^13.19.0",
+				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
-				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"is-path-inside": "^3.0.3",
-				"js-sdsl": "^4.1.4",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
 				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.1",
-				"regexpp": "^3.2.0",
+				"optionator": "^0.9.3",
 				"strip-ansi": "^6.0.1",
-				"strip-json-comments": "^3.1.0",
 				"text-table": "^0.2.0"
 			},
 			"bin": {
@@ -1809,14 +2146,16 @@
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint-scope": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmmirror.com/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
 			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 			"dev": true,
-			"license": "BSD-2-Clause",
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
@@ -1825,65 +2164,39 @@
 				"node": ">=8.0.0"
 			}
 		},
-		"node_modules/eslint-utils": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmmirror.com/eslint-utils/-/eslint-utils-3.0.0.tgz",
-			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+		"node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"eslint-visitor-keys": "^2.0.0"
-			},
 			"engines": {
-				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			},
-			"peerDependencies": {
-				"eslint": ">=5"
-			}
-		},
-		"node_modules/eslint-visitor-keys": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=10"
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint/node_modules/eslint-scope": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmmirror.com/eslint-scope/-/eslint-scope-7.1.1.tgz",
-			"integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/eslint/node_modules/eslint-visitor-keys": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint/node_modules/estraverse": {
 			"version": "5.3.0",
-			"resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -1893,7 +2206,6 @@
 			"resolved": "https://registry.npmmirror.com/glob-parent/-/glob-parent-6.0.2.tgz",
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"is-glob": "^4.0.3"
 			},
@@ -1902,36 +2214,27 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.4.1",
-			"resolved": "https://registry.npmmirror.com/espree/-/espree-9.4.1.tgz",
-			"integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
-				"acorn": "^8.8.0",
+				"acorn": "^8.9.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^3.3.0"
+				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/espree/node_modules/eslint-visitor-keys": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmmirror.com/esquery/-/esquery-1.4.0.tgz",
-			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -1941,20 +2244,18 @@
 		},
 		"node_modules/esquery/node_modules/estraverse": {
 			"version": "5.3.0",
-			"resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
 		},
 		"node_modules/esrecurse": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmmirror.com/esrecurse/-/esrecurse-4.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
-			"license": "BSD-2-Clause",
 			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
@@ -1964,20 +2265,18 @@
 		},
 		"node_modules/esrecurse/node_modules/estraverse": {
 			"version": "5.3.0",
-			"resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
-			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
 			}
 		},
 		"node_modules/estraverse": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-4.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true,
-			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -1987,7 +2286,6 @@
 			"resolved": "https://registry.npmmirror.com/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2014,10 +2312,9 @@
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
-			"resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/fast-glob": {
 			"version": "3.2.12",
@@ -2044,17 +2341,15 @@
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmmirror.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
-			"resolved": "https://registry.npmmirror.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/fastq": {
 			"version": "1.13.0",
@@ -2092,7 +2387,6 @@
 			"resolved": "https://registry.npmmirror.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"flat-cache": "^3.0.4"
 			},
@@ -2144,7 +2438,6 @@
 			"resolved": "https://registry.npmmirror.com/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -2158,7 +2451,6 @@
 			"resolved": "https://registry.npmmirror.com/flat-cache/-/flat-cache-3.0.4.tgz",
 			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"flatted": "^3.1.0",
 				"rimraf": "^3.0.2"
@@ -2172,7 +2464,6 @@
 			"resolved": "https://registry.npmmirror.com/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -2184,8 +2475,7 @@
 			"version": "3.2.7",
 			"resolved": "https://registry.npmmirror.com/flatted/-/flatted-3.2.7.tgz",
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/fp-ts": {
 			"version": "2.13.1",
@@ -2206,16 +2496,9 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/functional-red-black-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmmirror.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/get-monorepo-packages": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmmirror.com/get-monorepo-packages/-/get-monorepo-packages-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/get-monorepo-packages/-/get-monorepo-packages-1.2.0.tgz",
 			"integrity": "sha512-aDP6tH+eM3EuVSp3YyCutOcFS4Y9AhRRH9FAd+cjtR/g63Hx+DCXdKoP1ViRPUJz5wm+BOEXB4FhoffGHxJ7jQ==",
 			"dev": true,
 			"dependencies": {
@@ -2225,7 +2508,7 @@
 		},
 		"node_modules/get-monorepo-packages/node_modules/array-union": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmmirror.com/array-union/-/array-union-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
 			"dev": true,
 			"dependencies": {
@@ -2237,7 +2520,7 @@
 		},
 		"node_modules/get-monorepo-packages/node_modules/dir-glob": {
 			"version": "2.2.2",
-			"resolved": "https://registry.npmmirror.com/dir-glob/-/dir-glob-2.2.2.tgz",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
 			"integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
 			"dev": true,
 			"dependencies": {
@@ -2249,7 +2532,7 @@
 		},
 		"node_modules/get-monorepo-packages/node_modules/globby": {
 			"version": "7.1.1",
-			"resolved": "https://registry.npmmirror.com/globby/-/globby-7.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
 			"integrity": "sha512-yANWAN2DUcBtuus5Cpd+SKROzXHs2iVXFZt/Ykrfz6SAXqacLX25NZpltE+39ceMexYF4TtEadjuSTw8+3wX4g==",
 			"dev": true,
 			"dependencies": {
@@ -2266,13 +2549,13 @@
 		},
 		"node_modules/get-monorepo-packages/node_modules/ignore": {
 			"version": "3.3.10",
-			"resolved": "https://registry.npmmirror.com/ignore/-/ignore-3.3.10.tgz",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
 			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
 			"dev": true
 		},
 		"node_modules/get-monorepo-packages/node_modules/path-type": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmmirror.com/path-type/-/path-type-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"dev": true,
 			"dependencies": {
@@ -2284,7 +2567,7 @@
 		},
 		"node_modules/get-monorepo-packages/node_modules/slash": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmmirror.com/slash/-/slash-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
 			"integrity": "sha512-3TYDR7xWt4dIqV2JauJr+EJeW356RXijHeUlO+8djJ+uBXPn8/2dpzBc8yQhh583sVvc9CvFAeQVgijsH+PNNg==",
 			"dev": true,
 			"engines": {
@@ -2354,24 +2637,25 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "13.17.0",
-			"resolved": "https://registry.npmmirror.com/globals/-/globals-13.17.0.tgz",
-			"integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
 			},
 			"engines": {
 				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/globby": {
 			"version": "11.1.0",
-			"resolved": "https://registry.npmmirror.com/globby/-/globby-11.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
 			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
@@ -2393,12 +2677,11 @@
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
 			"dev": true
 		},
-		"node_modules/grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmmirror.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-			"dev": true,
-			"peer": true
+		"node_modules/graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+			"dev": true
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
@@ -2498,7 +2781,6 @@
 			"resolved": "https://registry.npmmirror.com/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.8.19"
 			}
@@ -2585,7 +2867,6 @@
 			"resolved": "https://registry.npmmirror.com/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2632,13 +2913,6 @@
 				"node": ">= 0.6.0"
 			}
 		},
-		"node_modules/js-sdsl": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmmirror.com/js-sdsl/-/js-sdsl-4.1.5.tgz",
-			"integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2647,10 +2921,9 @@
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -2672,24 +2945,21 @@
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmmirror.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/levn": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmmirror.com/levn/-/levn-0.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -2737,7 +3007,6 @@
 			"resolved": "https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -2767,8 +3036,7 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmmirror.com/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/log-symbols": {
 			"version": "4.1.0",
@@ -2903,8 +3171,13 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmmirror.com/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-			"dev": true,
-			"peer": true
+			"dev": true
+		},
+		"node_modules/natural-compare-lite": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+			"dev": true
 		},
 		"node_modules/nested-error-stacks": {
 			"version": "2.0.1",
@@ -2987,18 +3260,17 @@
 			}
 		},
 		"node_modules/optionator": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmmirror.com/optionator/-/optionator-0.9.1.tgz",
-			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
 				"levn": "^0.4.1",
 				"prelude-ls": "^1.2.1",
 				"type-check": "^0.4.0",
-				"word-wrap": "^1.2.3"
+				"word-wrap": "^1.2.5"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
@@ -3006,7 +3278,7 @@
 		},
 		"node_modules/os-homedir": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmmirror.com/os-homedir/-/os-homedir-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
 			"dev": true,
 			"engines": {
@@ -3018,7 +3290,6 @@
 			"resolved": "https://registry.npmmirror.com/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -3031,7 +3302,6 @@
 			"resolved": "https://registry.npmmirror.com/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -3113,7 +3383,6 @@
 			"resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3257,10 +3526,9 @@
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmmirror.com/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
@@ -3278,11 +3546,10 @@
 			}
 		},
 		"node_modules/punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmmirror.com/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -3367,22 +3634,9 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/regexpp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmmirror.com/regexpp/-/regexpp-3.2.0.tgz",
-			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			}
-		},
 		"node_modules/registry-url": {
 			"version": "5.1.0",
-			"resolved": "https://registry.npmmirror.com/registry-url/-/registry-url-5.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
 			"integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
 			"dev": true,
 			"dependencies": {
@@ -3601,10 +3855,9 @@
 		},
 		"node_modules/slash": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmmirror.com/slash/-/slash-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -3642,7 +3895,6 @@
 			"resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -3670,12 +3922,14 @@
 		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmmirror.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/strtok3": {
@@ -3782,8 +4036,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmmirror.com/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/tinycolor2": {
 			"version": "1.4.2",
@@ -3901,10 +4154,9 @@
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
-			"resolved": "https://registry.npmmirror.com/type-check/-/type-check-0.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1"
 			},
@@ -3914,12 +4166,14 @@
 		},
 		"node_modules/type-fest": {
 			"version": "0.20.2",
-			"resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-0.20.2.tgz",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/typescript": {
@@ -3959,10 +4213,9 @@
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
-			"resolved": "https://registry.npmmirror.com/uri-js/-/uri-js-4.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -3975,7 +4228,7 @@
 		},
 		"node_modules/user-home": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmmirror.com/user-home/-/user-home-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
 			"integrity": "sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==",
 			"dev": true,
 			"dependencies": {
@@ -4036,11 +4289,10 @@
 			}
 		},
 		"node_modules/word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmmirror.com/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -4104,7 +4356,6 @@
 			"resolved": "https://registry.npmmirror.com/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -4180,13 +4431,13 @@
 			}
 		},
 		"@auto-it/npm": {
-			"version": "10.37.6",
-			"resolved": "https://registry.npmmirror.com/@auto-it/npm/-/npm-10.37.6.tgz",
-			"integrity": "sha512-18CpaX3YfpJ6vwONYEBy9ORiPGplrtQ30pzRtDpKZzHin5wakdOyPd1P5lWeZBmCQCyiszdRteeQsXzFbaSuoQ==",
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@auto-it/npm/-/npm-11.1.6.tgz",
+			"integrity": "sha512-eFWzR+6N1lMSXi32BunnlIdXIFikX6mieaFLmPk9VNM4vOXqsfkc7BQ0xhsZRsn5sxSR/XBwlQXoExAHybjs3g==",
 			"dev": true,
 			"requires": {
-				"@auto-it/core": "10.37.6",
-				"@auto-it/package-json-utils": "10.37.6",
+				"@auto-it/core": "11.1.6",
+				"@auto-it/package-json-utils": "11.1.6",
 				"await-to-js": "^3.0.0",
 				"endent": "^2.1.0",
 				"env-ci": "^5.0.1",
@@ -4201,18 +4452,78 @@
 				"user-home": "^2.0.0"
 			},
 			"dependencies": {
+				"@auto-it/bot-list": {
+					"version": "11.1.6",
+					"resolved": "https://registry.npmjs.org/@auto-it/bot-list/-/bot-list-11.1.6.tgz",
+					"integrity": "sha512-3Qdphiw9JlzYX15moLZSaP+jNuM3UAFDHTgIpsfnfIQwQDNSjZhM4rwxqsAY/r1mJAyxt16c6wbqisi7KNFD/A==",
+					"dev": true
+				},
+				"@auto-it/core": {
+					"version": "11.1.6",
+					"resolved": "https://registry.npmjs.org/@auto-it/core/-/core-11.1.6.tgz",
+					"integrity": "sha512-bxiUXJVyRYs7Bf4DH/JLT5pdR14RYSpoX0eBw0ilkU9qNqylTCbThuKofM7Bqn7jaQF2PDUoC72c8xCkqvHGQg==",
+					"dev": true,
+					"requires": {
+						"@auto-it/bot-list": "11.1.6",
+						"@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
+						"@octokit/core": "^3.5.1",
+						"@octokit/plugin-enterprise-compatibility": "1.3.0",
+						"@octokit/plugin-retry": "^3.0.9",
+						"@octokit/plugin-throttling": "^3.6.2",
+						"@octokit/rest": "^18.12.0",
+						"await-to-js": "^3.0.0",
+						"chalk": "^4.0.0",
+						"cosmiconfig": "7.0.0",
+						"deepmerge": "^4.0.0",
+						"dotenv": "^8.0.0",
+						"endent": "^2.1.0",
+						"enquirer": "^2.3.4",
+						"env-ci": "^5.0.1",
+						"fast-glob": "^3.1.1",
+						"fp-ts": "^2.5.3",
+						"fromentries": "^1.2.0",
+						"gitlog": "^4.0.3",
+						"https-proxy-agent": "^5.0.0",
+						"import-cwd": "^3.0.0",
+						"import-from": "^3.0.0",
+						"io-ts": "^2.1.2",
+						"lodash.chunk": "^4.2.0",
+						"log-symbols": "^4.0.0",
+						"node-fetch": "2.6.7",
+						"parse-author": "^2.0.0",
+						"parse-github-url": "1.0.2",
+						"pretty-ms": "^7.0.0",
+						"requireg": "^0.2.2",
+						"semver": "^7.0.0",
+						"signale": "^1.4.0",
+						"tapable": "^2.2.0",
+						"terminal-link": "^2.1.1",
+						"tinycolor2": "^1.4.1",
+						"ts-node": "^10.9.1",
+						"tslib": "2.1.0",
+						"type-fest": "^0.21.1",
+						"typescript-memoize": "^1.0.0-alpha.3",
+						"url-join": "^4.0.0"
+					}
+				},
 				"tslib": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
 					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+					"dev": true
+				},
+				"type-fest": {
+					"version": "0.21.3",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+					"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
 					"dev": true
 				}
 			}
 		},
 		"@auto-it/package-json-utils": {
-			"version": "10.37.6",
-			"resolved": "https://registry.npmmirror.com/@auto-it/package-json-utils/-/package-json-utils-10.37.6.tgz",
-			"integrity": "sha512-rUoEcEnPgHG8X/XkPe3PKFHhXD3AsplXB0Rpr7lJQta5XzDqmWzc/xVL1vMmM4IpXMI5lK7A9OZosWjgJVI7jA==",
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@auto-it/package-json-utils/-/package-json-utils-11.1.6.tgz",
+			"integrity": "sha512-RSXmO+KegaEY7uw1vt8iXL9FShiinFigKNFuIWM9oLSaSHJfeQ2ZD291i9nV+tz86bPGySBb5ktdJ3uo2pAZ+Q==",
 			"dev": true,
 			"requires": {
 				"parse-author": "^2.0.0",
@@ -4220,23 +4531,83 @@
 			}
 		},
 		"@auto-it/released": {
-			"version": "10.37.6",
-			"resolved": "https://registry.npmmirror.com/@auto-it/released/-/released-10.37.6.tgz",
-			"integrity": "sha512-988nCdYApyzKwZx6W6lHNHS9aEw9xLFbfDcTWrSKUOChjT8yDcGadDDXVhj3M0uhHojr8jXKbrRATEPyEeTDlg==",
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@auto-it/released/-/released-11.1.6.tgz",
+			"integrity": "sha512-RHTSjq5fAQxkhcC84aWItotyPGH67o+bzSxzr9H4mzvP8OrIxj7Jsfmk8wT4rjgupCTl9fu8DiGoCGjcQpCdCw==",
 			"dev": true,
 			"requires": {
-				"@auto-it/bot-list": "10.37.6",
-				"@auto-it/core": "10.37.6",
+				"@auto-it/bot-list": "11.1.6",
+				"@auto-it/core": "11.1.6",
 				"deepmerge": "^4.0.0",
 				"fp-ts": "^2.5.3",
 				"io-ts": "^2.1.2",
 				"tslib": "2.1.0"
 			},
 			"dependencies": {
+				"@auto-it/bot-list": {
+					"version": "11.1.6",
+					"resolved": "https://registry.npmjs.org/@auto-it/bot-list/-/bot-list-11.1.6.tgz",
+					"integrity": "sha512-3Qdphiw9JlzYX15moLZSaP+jNuM3UAFDHTgIpsfnfIQwQDNSjZhM4rwxqsAY/r1mJAyxt16c6wbqisi7KNFD/A==",
+					"dev": true
+				},
+				"@auto-it/core": {
+					"version": "11.1.6",
+					"resolved": "https://registry.npmjs.org/@auto-it/core/-/core-11.1.6.tgz",
+					"integrity": "sha512-bxiUXJVyRYs7Bf4DH/JLT5pdR14RYSpoX0eBw0ilkU9qNqylTCbThuKofM7Bqn7jaQF2PDUoC72c8xCkqvHGQg==",
+					"dev": true,
+					"requires": {
+						"@auto-it/bot-list": "11.1.6",
+						"@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
+						"@octokit/core": "^3.5.1",
+						"@octokit/plugin-enterprise-compatibility": "1.3.0",
+						"@octokit/plugin-retry": "^3.0.9",
+						"@octokit/plugin-throttling": "^3.6.2",
+						"@octokit/rest": "^18.12.0",
+						"await-to-js": "^3.0.0",
+						"chalk": "^4.0.0",
+						"cosmiconfig": "7.0.0",
+						"deepmerge": "^4.0.0",
+						"dotenv": "^8.0.0",
+						"endent": "^2.1.0",
+						"enquirer": "^2.3.4",
+						"env-ci": "^5.0.1",
+						"fast-glob": "^3.1.1",
+						"fp-ts": "^2.5.3",
+						"fromentries": "^1.2.0",
+						"gitlog": "^4.0.3",
+						"https-proxy-agent": "^5.0.0",
+						"import-cwd": "^3.0.0",
+						"import-from": "^3.0.0",
+						"io-ts": "^2.1.2",
+						"lodash.chunk": "^4.2.0",
+						"log-symbols": "^4.0.0",
+						"node-fetch": "2.6.7",
+						"parse-author": "^2.0.0",
+						"parse-github-url": "1.0.2",
+						"pretty-ms": "^7.0.0",
+						"requireg": "^0.2.2",
+						"semver": "^7.0.0",
+						"signale": "^1.4.0",
+						"tapable": "^2.2.0",
+						"terminal-link": "^2.1.1",
+						"tinycolor2": "^1.4.1",
+						"ts-node": "^10.9.1",
+						"tslib": "2.1.0",
+						"type-fest": "^0.21.1",
+						"typescript-memoize": "^1.0.0-alpha.3",
+						"url-join": "^4.0.0"
+					}
+				},
 				"tslib": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
 					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+					"dev": true
+				},
+				"type-fest": {
+					"version": "0.21.3",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+					"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
 					"dev": true
 				}
 			}
@@ -4266,22 +4637,90 @@
 			}
 		},
 		"@auto-it/version-file": {
-			"version": "10.37.6",
-			"resolved": "https://registry.npmmirror.com/@auto-it/version-file/-/version-file-10.37.6.tgz",
-			"integrity": "sha512-BO7f1bWrUFkhp7RwwmkegBUc/VwJrIlQQaFm7l/cc5IGZ7DL0rPap8UbytSL3aWV9YzoZpqgWNj2KPRGvwguag==",
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@auto-it/version-file/-/version-file-11.1.6.tgz",
+			"integrity": "sha512-iDAK0IrCYFPDgkX4DGB97VFbiFEfxN+IMW1NiF+Qk7Kd3SX2899vwuFxyVvGwovX7ssuCi/4tSTrvx6PLhH6zw==",
 			"dev": true,
 			"requires": {
-				"@auto-it/core": "10.37.6",
+				"@auto-it/core": "11.1.6",
 				"fp-ts": "^2.5.3",
 				"io-ts": "^2.1.2",
 				"semver": "^7.0.0",
 				"tslib": "1.10.0"
 			},
 			"dependencies": {
+				"@auto-it/bot-list": {
+					"version": "11.1.6",
+					"resolved": "https://registry.npmjs.org/@auto-it/bot-list/-/bot-list-11.1.6.tgz",
+					"integrity": "sha512-3Qdphiw9JlzYX15moLZSaP+jNuM3UAFDHTgIpsfnfIQwQDNSjZhM4rwxqsAY/r1mJAyxt16c6wbqisi7KNFD/A==",
+					"dev": true
+				},
+				"@auto-it/core": {
+					"version": "11.1.6",
+					"resolved": "https://registry.npmjs.org/@auto-it/core/-/core-11.1.6.tgz",
+					"integrity": "sha512-bxiUXJVyRYs7Bf4DH/JLT5pdR14RYSpoX0eBw0ilkU9qNqylTCbThuKofM7Bqn7jaQF2PDUoC72c8xCkqvHGQg==",
+					"dev": true,
+					"requires": {
+						"@auto-it/bot-list": "11.1.6",
+						"@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
+						"@octokit/core": "^3.5.1",
+						"@octokit/plugin-enterprise-compatibility": "1.3.0",
+						"@octokit/plugin-retry": "^3.0.9",
+						"@octokit/plugin-throttling": "^3.6.2",
+						"@octokit/rest": "^18.12.0",
+						"await-to-js": "^3.0.0",
+						"chalk": "^4.0.0",
+						"cosmiconfig": "7.0.0",
+						"deepmerge": "^4.0.0",
+						"dotenv": "^8.0.0",
+						"endent": "^2.1.0",
+						"enquirer": "^2.3.4",
+						"env-ci": "^5.0.1",
+						"fast-glob": "^3.1.1",
+						"fp-ts": "^2.5.3",
+						"fromentries": "^1.2.0",
+						"gitlog": "^4.0.3",
+						"https-proxy-agent": "^5.0.0",
+						"import-cwd": "^3.0.0",
+						"import-from": "^3.0.0",
+						"io-ts": "^2.1.2",
+						"lodash.chunk": "^4.2.0",
+						"log-symbols": "^4.0.0",
+						"node-fetch": "2.6.7",
+						"parse-author": "^2.0.0",
+						"parse-github-url": "1.0.2",
+						"pretty-ms": "^7.0.0",
+						"requireg": "^0.2.2",
+						"semver": "^7.0.0",
+						"signale": "^1.4.0",
+						"tapable": "^2.2.0",
+						"terminal-link": "^2.1.1",
+						"tinycolor2": "^1.4.1",
+						"ts-node": "^10.9.1",
+						"tslib": "2.1.0",
+						"type-fest": "^0.21.1",
+						"typescript-memoize": "^1.0.0-alpha.3",
+						"url-join": "^4.0.0"
+					},
+					"dependencies": {
+						"tslib": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+							"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+							"dev": true
+						}
+					}
+				},
 				"tslib": {
 					"version": "1.10.0",
-					"resolved": "https://registry.npmmirror.com/tslib/-/tslib-1.10.0.tgz",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
 					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+					"dev": true
+				},
+				"type-fest": {
+					"version": "0.21.3",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+					"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
 					"dev": true
 				}
 			}
@@ -4426,17 +4865,31 @@
 				}
 			}
 		},
-		"@eslint/eslintrc": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmmirror.com/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-			"integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+		"@eslint-community/eslint-utils": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
 			"dev": true,
-			"peer": true,
+			"requires": {
+				"eslint-visitor-keys": "^3.3.0"
+			}
+		},
+		"@eslint-community/regexpp": {
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
+			"integrity": "sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==",
+			"dev": true
+		},
+		"@eslint/eslintrc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.4.0",
-				"globals": "^13.15.0",
+				"espree": "^9.6.0",
+				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
@@ -4444,15 +4897,20 @@
 				"strip-json-comments": "^3.1.1"
 			}
 		},
+		"@eslint/js": {
+			"version": "8.57.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+			"dev": true
+		},
 		"@humanwhocodes/config-array": {
-			"version": "0.11.7",
-			"resolved": "https://registry.npmmirror.com/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-			"integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
+			"version": "0.11.14",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
-				"@humanwhocodes/object-schema": "^1.2.1",
-				"debug": "^4.1.1",
+				"@humanwhocodes/object-schema": "^2.0.2",
+				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
 			}
 		},
@@ -4460,15 +4918,13 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmmirror.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@humanwhocodes/object-schema": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmmirror.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-			"dev": true,
-			"peer": true
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+			"dev": true
 		},
 		"@jridgewell/resolve-uri": {
 			"version": "3.1.0",
@@ -4730,9 +5186,9 @@
 			"dev": true
 		},
 		"@types/json-schema": {
-			"version": "7.0.11",
-			"resolved": "https://registry.npmmirror.com/@types/json-schema/-/json-schema-7.0.11.tgz",
-			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true
 		},
 		"@types/md5": {
@@ -4753,6 +5209,12 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
 			"dev": true
 		},
+		"@types/semver": {
+			"version": "7.5.8",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+			"integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+			"dev": true
+		},
 		"@types/tern": {
 			"version": "0.23.4",
 			"resolved": "https://registry.npmmirror.com/@types/tern/-/tern-0.23.4.tgz",
@@ -4763,69 +5225,71 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.29.0.tgz",
-			"integrity": "sha512-kgTsISt9pM53yRFQmLZ4npj99yGl3x3Pl7z4eA66OuTzAGC4bQB5H5fuLwPnqTKU3yyrrg4MIhjF17UYnL4c0w==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+			"integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.29.0",
-				"@typescript-eslint/type-utils": "5.29.0",
-				"@typescript-eslint/utils": "5.29.0",
+				"@eslint-community/regexpp": "^4.4.0",
+				"@typescript-eslint/scope-manager": "5.62.0",
+				"@typescript-eslint/type-utils": "5.62.0",
+				"@typescript-eslint/utils": "5.62.0",
 				"debug": "^4.3.4",
-				"functional-red-black-tree": "^1.0.1",
+				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
-				"regexpp": "^3.2.0",
+				"natural-compare-lite": "^1.4.0",
 				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/parser/-/parser-5.29.0.tgz",
-			"integrity": "sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+			"integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.29.0",
-				"@typescript-eslint/types": "5.29.0",
-				"@typescript-eslint/typescript-estree": "5.29.0",
+				"@typescript-eslint/scope-manager": "5.62.0",
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/typescript-estree": "5.62.0",
 				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz",
-			"integrity": "sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+			"integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.29.0",
-				"@typescript-eslint/visitor-keys": "5.29.0"
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/visitor-keys": "5.62.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/type-utils/-/type-utils-5.29.0.tgz",
-			"integrity": "sha512-JK6bAaaiJozbox3K220VRfCzLa9n0ib/J+FHIwnaV3Enw/TO267qe0pM1b1QrrEuy6xun374XEAsRlA86JJnyg==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+			"integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/utils": "5.29.0",
+				"@typescript-eslint/typescript-estree": "5.62.0",
+				"@typescript-eslint/utils": "5.62.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/types/-/types-5.29.0.tgz",
-			"integrity": "sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+			"integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz",
-			"integrity": "sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+			"integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.29.0",
-				"@typescript-eslint/visitor-keys": "5.29.0",
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/visitor-keys": "5.62.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -4834,49 +5298,48 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/utils/-/utils-5.29.0.tgz",
-			"integrity": "sha512-3Eos6uP1nyLOBayc/VUdKZikV90HahXE5Dx9L5YlSd/7ylQPXhLk1BYb29SDgnBnTp+jmSZUU0QxUiyHgW4p7A==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+			"integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
 			"dev": true,
 			"requires": {
+				"@eslint-community/eslint-utils": "^4.2.0",
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.29.0",
-				"@typescript-eslint/types": "5.29.0",
-				"@typescript-eslint/typescript-estree": "5.29.0",
+				"@types/semver": "^7.3.12",
+				"@typescript-eslint/scope-manager": "5.62.0",
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/typescript-estree": "5.62.0",
 				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0"
+				"semver": "^7.3.7"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz",
-			"integrity": "sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+			"integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.29.0",
+				"@typescript-eslint/types": "5.62.0",
 				"eslint-visitor-keys": "^3.3.0"
-			},
-			"dependencies": {
-				"eslint-visitor-keys": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-					"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-					"dev": true
-				}
 			}
 		},
+		"@ungap/structured-clone": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+			"dev": true
+		},
 		"acorn": {
-			"version": "8.8.1",
-			"resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.8.1.tgz",
-			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+			"version": "8.11.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
 			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
-			"resolved": "https://registry.npmmirror.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {}
 		},
 		"acorn-walk": {
@@ -4896,10 +5359,9 @@
 		},
 		"ajv": {
 			"version": "6.12.6",
-			"resolved": "https://registry.npmmirror.com/ajv/-/ajv-6.12.6.tgz",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -4934,8 +5396,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "4.3.0",
@@ -4954,10 +5415,9 @@
 		},
 		"argparse": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmmirror.com/argparse/-/argparse-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"array-back": {
 			"version": "3.1.0",
@@ -4967,13 +5427,13 @@
 		},
 		"array-union": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmmirror.com/array-union/-/array-union-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true
 		},
 		"array-uniq": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmmirror.com/array-uniq/-/array-uniq-1.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
 			"integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
 			"dev": true
 		},
@@ -4984,15 +5444,15 @@
 			"dev": true
 		},
 		"auto": {
-			"version": "10.37.6",
-			"resolved": "https://registry.npmmirror.com/auto/-/auto-10.37.6.tgz",
-			"integrity": "sha512-zMLsXz/WPqSlNVlY6g1GlFyhow+x//htR2QwWYSxB4DvAFNggXnK6aRqJ1DrcjhtUAPL2ngw5hHHrCgHvyvAaw==",
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/auto/-/auto-11.1.6.tgz",
+			"integrity": "sha512-GKeZbFWPp7V9d+yWuFvaffVNyLSGFpR/+SrzXt29YKhg8axx5bKQKzbBN0eSzX5DLmhBwS81tWXS+SYpECil9Q==",
 			"dev": true,
 			"requires": {
-				"@auto-it/core": "10.37.6",
-				"@auto-it/npm": "10.37.6",
-				"@auto-it/released": "10.37.6",
-				"@auto-it/version-file": "10.37.6",
+				"@auto-it/core": "11.1.6",
+				"@auto-it/npm": "11.1.6",
+				"@auto-it/released": "11.1.6",
+				"@auto-it/version-file": "11.1.6",
 				"await-to-js": "^3.0.0",
 				"chalk": "^4.0.0",
 				"command-line-application": "^0.10.1",
@@ -5003,18 +5463,78 @@
 				"tslib": "2.1.0"
 			},
 			"dependencies": {
+				"@auto-it/bot-list": {
+					"version": "11.1.6",
+					"resolved": "https://registry.npmjs.org/@auto-it/bot-list/-/bot-list-11.1.6.tgz",
+					"integrity": "sha512-3Qdphiw9JlzYX15moLZSaP+jNuM3UAFDHTgIpsfnfIQwQDNSjZhM4rwxqsAY/r1mJAyxt16c6wbqisi7KNFD/A==",
+					"dev": true
+				},
+				"@auto-it/core": {
+					"version": "11.1.6",
+					"resolved": "https://registry.npmjs.org/@auto-it/core/-/core-11.1.6.tgz",
+					"integrity": "sha512-bxiUXJVyRYs7Bf4DH/JLT5pdR14RYSpoX0eBw0ilkU9qNqylTCbThuKofM7Bqn7jaQF2PDUoC72c8xCkqvHGQg==",
+					"dev": true,
+					"requires": {
+						"@auto-it/bot-list": "11.1.6",
+						"@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
+						"@octokit/core": "^3.5.1",
+						"@octokit/plugin-enterprise-compatibility": "1.3.0",
+						"@octokit/plugin-retry": "^3.0.9",
+						"@octokit/plugin-throttling": "^3.6.2",
+						"@octokit/rest": "^18.12.0",
+						"await-to-js": "^3.0.0",
+						"chalk": "^4.0.0",
+						"cosmiconfig": "7.0.0",
+						"deepmerge": "^4.0.0",
+						"dotenv": "^8.0.0",
+						"endent": "^2.1.0",
+						"enquirer": "^2.3.4",
+						"env-ci": "^5.0.1",
+						"fast-glob": "^3.1.1",
+						"fp-ts": "^2.5.3",
+						"fromentries": "^1.2.0",
+						"gitlog": "^4.0.3",
+						"https-proxy-agent": "^5.0.0",
+						"import-cwd": "^3.0.0",
+						"import-from": "^3.0.0",
+						"io-ts": "^2.1.2",
+						"lodash.chunk": "^4.2.0",
+						"log-symbols": "^4.0.0",
+						"node-fetch": "2.6.7",
+						"parse-author": "^2.0.0",
+						"parse-github-url": "1.0.2",
+						"pretty-ms": "^7.0.0",
+						"requireg": "^0.2.2",
+						"semver": "^7.0.0",
+						"signale": "^1.4.0",
+						"tapable": "^2.2.0",
+						"terminal-link": "^2.1.1",
+						"tinycolor2": "^1.4.1",
+						"ts-node": "^10.9.1",
+						"tslib": "2.1.0",
+						"type-fest": "^0.21.1",
+						"typescript-memoize": "^1.0.0-alpha.3",
+						"url-join": "^4.0.0"
+					}
+				},
 				"tslib": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.1.0.tgz",
 					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
 					"dev": true
+				},
+				"type-fest": {
+					"version": "0.21.3",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+					"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+					"dev": true
 				}
 			}
 		},
 		"auto-plugin-obsidian": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmmirror.com/auto-plugin-obsidian/-/auto-plugin-obsidian-0.1.4.tgz",
-			"integrity": "sha512-g6Ee9j+0HgphKpKfSmVhqcDT+ITxxXmMAcGWawyJnNcUIQ5ZwFcidN6RcuI9DN2bUCtFTHLuFTIprne+ZGbJdw==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/auto-plugin-obsidian/-/auto-plugin-obsidian-0.1.6.tgz",
+			"integrity": "sha512-d/aROWf81wFSo9QSPjdVFMv3yJWRCJphnnWu8X86lGITDTwwni3vk/5LjP9brtHTesFLMm5lFeEjWu7+n4vZ0A==",
 			"dev": true,
 			"requires": {
 				"@auto-it/core": "^10.16.5",
@@ -5354,10 +5874,9 @@
 		},
 		"deep-is": {
 			"version": "0.1.4",
-			"resolved": "https://registry.npmmirror.com/deep-is/-/deep-is-0.1.4.tgz",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"deepmerge": {
 			"version": "4.2.2",
@@ -5379,7 +5898,7 @@
 		},
 		"dir-glob": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmmirror.com/dir-glob/-/dir-glob-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
 			"dev": true,
 			"requires": {
@@ -5391,7 +5910,6 @@
 			"resolved": "https://registry.npmmirror.com/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"esutils": "^2.0.2"
 			}
@@ -5481,88 +5999,75 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"eslint": {
-			"version": "8.27.0",
-			"resolved": "https://registry.npmmirror.com/eslint/-/eslint-8.27.0.tgz",
-			"integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
+			"version": "8.57.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+			"integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
-				"@eslint/eslintrc": "^1.3.3",
-				"@humanwhocodes/config-array": "^0.11.6",
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.6.1",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.57.0",
+				"@humanwhocodes/config-array": "^0.11.14",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
-				"ajv": "^6.10.0",
+				"@ungap/structured-clone": "^1.2.0",
+				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
 				"debug": "^4.3.2",
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.1.1",
-				"eslint-utils": "^3.0.0",
-				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.4.0",
-				"esquery": "^1.4.0",
+				"eslint-scope": "^7.2.2",
+				"eslint-visitor-keys": "^3.4.3",
+				"espree": "^9.6.1",
+				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
 				"glob-parent": "^6.0.2",
-				"globals": "^13.15.0",
-				"grapheme-splitter": "^1.0.4",
+				"globals": "^13.19.0",
+				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
-				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"is-path-inside": "^3.0.3",
-				"js-sdsl": "^4.1.4",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
 				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.1",
-				"regexpp": "^3.2.0",
+				"optionator": "^0.9.3",
 				"strip-ansi": "^6.0.1",
-				"strip-json-comments": "^3.1.0",
 				"text-table": "^0.2.0"
 			},
 			"dependencies": {
 				"eslint-scope": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmmirror.com/eslint-scope/-/eslint-scope-7.1.1.tgz",
-					"integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+					"version": "7.2.2",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+					"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 					"dev": true,
-					"peer": true,
 					"requires": {
 						"esrecurse": "^4.3.0",
 						"estraverse": "^5.2.0"
 					}
 				},
-				"eslint-visitor-keys": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-					"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-					"dev": true,
-					"peer": true
-				},
 				"estraverse": {
 					"version": "5.3.0",
-					"resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true,
-					"peer": true
+					"dev": true
 				},
 				"glob-parent": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmmirror.com/glob-parent/-/glob-parent-6.0.2.tgz",
 					"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 					"dev": true,
-					"peer": true,
 					"requires": {
 						"is-glob": "^4.0.3"
 					}
@@ -5571,7 +6076,7 @@
 		},
 		"eslint-scope": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmmirror.com/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
 			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 			"dev": true,
 			"requires": {
@@ -5579,64 +6084,43 @@
 				"estraverse": "^4.1.1"
 			}
 		},
-		"eslint-utils": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmmirror.com/eslint-utils/-/eslint-utils-3.0.0.tgz",
-			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-			"dev": true,
-			"requires": {
-				"eslint-visitor-keys": "^2.0.0"
-			}
-		},
 		"eslint-visitor-keys": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true
 		},
 		"espree": {
-			"version": "9.4.1",
-			"resolved": "https://registry.npmmirror.com/espree/-/espree-9.4.1.tgz",
-			"integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
-				"acorn": "^8.8.0",
+				"acorn": "^8.9.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^3.3.0"
-			},
-			"dependencies": {
-				"eslint-visitor-keys": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-					"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-					"dev": true,
-					"peer": true
-				}
+				"eslint-visitor-keys": "^3.4.1"
 			}
 		},
 		"esquery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmmirror.com/esquery/-/esquery-1.4.0.tgz",
-			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"estraverse": "^5.1.0"
 			},
 			"dependencies": {
 				"estraverse": {
 					"version": "5.3.0",
-					"resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true,
-					"peer": true
+					"dev": true
 				}
 			}
 		},
 		"esrecurse": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmmirror.com/esrecurse/-/esrecurse-4.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
 			"requires": {
@@ -5645,7 +6129,7 @@
 			"dependencies": {
 				"estraverse": {
 					"version": "5.3.0",
-					"resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 					"dev": true
 				}
@@ -5653,7 +6137,7 @@
 		},
 		"estraverse": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-4.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true
 		},
@@ -5661,8 +6145,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmmirror.com/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"execa": {
 			"version": "5.1.1",
@@ -5683,10 +6166,9 @@
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
-			"resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"fast-glob": {
 			"version": "3.2.12",
@@ -5709,17 +6191,15 @@
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmmirror.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
-			"resolved": "https://registry.npmmirror.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"fastq": {
 			"version": "1.13.0",
@@ -5752,7 +6232,6 @@
 			"resolved": "https://registry.npmmirror.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"flat-cache": "^3.0.4"
 			}
@@ -5791,7 +6270,6 @@
 			"resolved": "https://registry.npmmirror.com/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -5802,7 +6280,6 @@
 			"resolved": "https://registry.npmmirror.com/flat-cache/-/flat-cache-3.0.4.tgz",
 			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"flatted": "^3.1.0",
 				"rimraf": "^3.0.2"
@@ -5813,7 +6290,6 @@
 					"resolved": "https://registry.npmmirror.com/rimraf/-/rimraf-3.0.2.tgz",
 					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 					"dev": true,
-					"peer": true,
 					"requires": {
 						"glob": "^7.1.3"
 					}
@@ -5824,8 +6300,7 @@
 			"version": "3.2.7",
 			"resolved": "https://registry.npmmirror.com/flatted/-/flatted-3.2.7.tgz",
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"fp-ts": {
 			"version": "2.13.1",
@@ -5845,15 +6320,9 @@
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
 		},
-		"functional-red-black-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmmirror.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-			"dev": true
-		},
 		"get-monorepo-packages": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmmirror.com/get-monorepo-packages/-/get-monorepo-packages-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/get-monorepo-packages/-/get-monorepo-packages-1.2.0.tgz",
 			"integrity": "sha512-aDP6tH+eM3EuVSp3YyCutOcFS4Y9AhRRH9FAd+cjtR/g63Hx+DCXdKoP1ViRPUJz5wm+BOEXB4FhoffGHxJ7jQ==",
 			"dev": true,
 			"requires": {
@@ -5863,7 +6332,7 @@
 			"dependencies": {
 				"array-union": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmmirror.com/array-union/-/array-union-1.0.2.tgz",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 					"integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
 					"dev": true,
 					"requires": {
@@ -5872,7 +6341,7 @@
 				},
 				"dir-glob": {
 					"version": "2.2.2",
-					"resolved": "https://registry.npmmirror.com/dir-glob/-/dir-glob-2.2.2.tgz",
+					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
 					"integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
 					"dev": true,
 					"requires": {
@@ -5881,7 +6350,7 @@
 				},
 				"globby": {
 					"version": "7.1.1",
-					"resolved": "https://registry.npmmirror.com/globby/-/globby-7.1.1.tgz",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
 					"integrity": "sha512-yANWAN2DUcBtuus5Cpd+SKROzXHs2iVXFZt/Ykrfz6SAXqacLX25NZpltE+39ceMexYF4TtEadjuSTw8+3wX4g==",
 					"dev": true,
 					"requires": {
@@ -5895,13 +6364,13 @@
 				},
 				"ignore": {
 					"version": "3.3.10",
-					"resolved": "https://registry.npmmirror.com/ignore/-/ignore-3.3.10.tgz",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
 					"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
 					"dev": true
 				},
 				"path-type": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmmirror.com/path-type/-/path-type-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
@@ -5910,7 +6379,7 @@
 				},
 				"slash": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmmirror.com/slash/-/slash-1.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
 					"integrity": "sha512-3TYDR7xWt4dIqV2JauJr+EJeW356RXijHeUlO+8djJ+uBXPn8/2dpzBc8yQhh583sVvc9CvFAeQVgijsH+PNNg==",
 					"dev": true
 				}
@@ -5964,18 +6433,17 @@
 			}
 		},
 		"globals": {
-			"version": "13.17.0",
-			"resolved": "https://registry.npmmirror.com/globals/-/globals-13.17.0.tgz",
-			"integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"type-fest": "^0.20.2"
 			}
 		},
 		"globby": {
 			"version": "11.1.0",
-			"resolved": "https://registry.npmmirror.com/globby/-/globby-11.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
 			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"dev": true,
 			"requires": {
@@ -5993,12 +6461,11 @@
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
 			"dev": true
 		},
-		"grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmmirror.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-			"dev": true,
-			"peer": true
+		"graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+			"dev": true
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -6074,8 +6541,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmmirror.com/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -6142,8 +6608,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmmirror.com/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"is-plain-object": {
 			"version": "5.0.0",
@@ -6175,13 +6640,6 @@
 			"integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
 			"dev": true
 		},
-		"js-sdsl": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmmirror.com/js-sdsl/-/js-sdsl-4.1.5.tgz",
-			"integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
-			"dev": true,
-			"peer": true
-		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6190,10 +6648,9 @@
 		},
 		"js-yaml": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"argparse": "^2.0.1"
 			}
@@ -6212,24 +6669,21 @@
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmmirror.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"levn": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmmirror.com/levn/-/levn-0.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -6270,7 +6724,6 @@
 			"resolved": "https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"p-locate": "^5.0.0"
 			}
@@ -6297,8 +6750,7 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmmirror.com/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"log-symbols": {
 			"version": "4.1.0",
@@ -6406,8 +6858,13 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmmirror.com/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-			"dev": true,
-			"peer": true
+			"dev": true
+		},
+		"natural-compare-lite": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+			"dev": true
 		},
 		"nested-error-stacks": {
 			"version": "2.0.1",
@@ -6468,23 +6925,22 @@
 			}
 		},
 		"optionator": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmmirror.com/optionator/-/optionator-0.9.1.tgz",
-			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
 				"levn": "^0.4.1",
 				"prelude-ls": "^1.2.1",
 				"type-check": "^0.4.0",
-				"word-wrap": "^1.2.3"
+				"word-wrap": "^1.2.5"
 			}
 		},
 		"os-homedir": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmmirror.com/os-homedir/-/os-homedir-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
 			"dev": true
 		},
@@ -6493,7 +6949,6 @@
 			"resolved": "https://registry.npmmirror.com/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"yocto-queue": "^0.1.0"
 			}
@@ -6503,7 +6958,6 @@
 			"resolved": "https://registry.npmmirror.com/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"p-limit": "^3.0.2"
 			}
@@ -6560,8 +7014,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -6662,10 +7115,9 @@
 		},
 		"prelude-ls": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmmirror.com/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"pretty-ms": {
 			"version": "7.0.1",
@@ -6677,11 +7129,10 @@
 			}
 		},
 		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmmirror.com/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true,
-			"peer": true
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true
 		},
 		"queue-microtask": {
 			"version": "1.2.3",
@@ -6735,15 +7186,9 @@
 			"integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
 			"dev": true
 		},
-		"regexpp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmmirror.com/regexpp/-/regexpp-3.2.0.tgz",
-			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-			"dev": true
-		},
 		"registry-url": {
 			"version": "5.1.0",
-			"resolved": "https://registry.npmmirror.com/registry-url/-/registry-url-5.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
 			"integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
 			"dev": true,
 			"requires": {
@@ -6904,7 +7349,7 @@
 		},
 		"slash": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmmirror.com/slash/-/slash-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true
 		},
@@ -6938,7 +7383,6 @@
 			"resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"ansi-regex": "^5.0.1"
 			}
@@ -6957,10 +7401,9 @@
 		},
 		"strip-json-comments": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmmirror.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"strtok3": {
 			"version": "6.3.0",
@@ -7044,8 +7487,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmmirror.com/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"tinycolor2": {
 			"version": "1.4.2",
@@ -7124,20 +7566,18 @@
 		},
 		"type-check": {
 			"version": "0.4.0",
-			"resolved": "https://registry.npmmirror.com/type-check/-/type-check-0.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"prelude-ls": "^1.2.1"
 			}
 		},
 		"type-fest": {
 			"version": "0.20.2",
-			"resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-0.20.2.tgz",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"typescript": {
 			"version": "4.7.4",
@@ -7165,10 +7605,9 @@
 		},
 		"uri-js": {
 			"version": "4.4.1",
-			"resolved": "https://registry.npmmirror.com/uri-js/-/uri-js-4.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -7181,7 +7620,7 @@
 		},
 		"user-home": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmmirror.com/user-home/-/user-home-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
 			"integrity": "sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==",
 			"dev": true,
 			"requires": {
@@ -7233,11 +7672,10 @@
 			}
 		},
 		"word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmmirror.com/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-			"dev": true,
-			"peer": true
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+			"dev": true
 		},
 		"wordwrapjs": {
 			"version": "4.0.1",
@@ -7285,8 +7723,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmmirror.com/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		}
 	}
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 export const ATTACHMENT_URL_REGEXP =
-	/!\[\[((.*?)\.(\w+))(?:\s*\|\s*(\d+)\s*(?:\*\s*(\d+))?)?\]\]/g;
+	/!\[\[((.*?)\.(\w+))(?:\s*\|\s*(?<width>\d+)\s*(?:[*|x]\s*(?<height>\d+))?)?\]\]/g;
 
 export const MARKDOWN_ATTACHMENT_URL_REGEXP = /!\[(.*?)\]\(((.*?)\.(\w+))\)/g;
 
@@ -7,16 +7,22 @@ export const EMBED_URL_REGEXP = /!\[\[(.*?)\]\]/g;
 
 export const GFM_IMAGE_FORMAT = "![]({0})";
 
+export const OUTGOING_LINK_REGEXP = /[^!]\[\[(.*?)\]\]/g;
+
 export interface MarkdownExportPluginSettings {
 	output: string;
 	attachment: string;
+	displayImageAsHtml: boolean;
 	GFM: boolean;
 	fileNameEncode: boolean;
+	removeOutgoingLinkBrackets: boolean;
 }
 
 export const DEFAULT_SETTINGS: MarkdownExportPluginSettings = {
 	output: "output",
 	attachment: "attachment",
+	displayImageAsHtml: true,
 	GFM: true,
 	fileNameEncode: true,
+	removeOutgoingLinkBrackets: true,
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ export const EMBED_URL_REGEXP = /!\[\[(.*?)\]\]/g;
 
 export const GFM_IMAGE_FORMAT = "![]({0})";
 
-export const OUTGOING_LINK_REGEXP = /[^!]\[\[(.*?)\]\]/g;
+export const OUTGOING_LINK_REGEXP = /(?<!!)\[\[(.*?)\]\]/g;
 
 export interface MarkdownExportPluginSettings {
 	output: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,7 @@ export default class MarkdownExportPlugin extends Plugin {
 				// 	}
 				// 	menu.addItem(addFileMenuItem);
 				// }
-			})
+			}),
 		);
 
 		for (const outputFormat of ["markdown", "HTML"]) {
@@ -70,12 +70,12 @@ export default class MarkdownExportPlugin extends Plugin {
 	}
 	private async createFolderAndRun(
 		file: TAbstractFile,
-		outputFormat: string
+		outputFormat: string,
 	) {
 		// try create attachment directory
 		await tryCreateFolder(
 			this,
-			path.join(this.settings.output, this.settings.attachment)
+			path.join(this.settings.output, this.settings.attachment),
 		);
 
 		// run
@@ -84,18 +84,18 @@ export default class MarkdownExportPlugin extends Plugin {
 		new Notice(
 			`Exporting ${file.path} to ${path.join(
 				this.settings.output,
-				file.name
-			)}`
+				file.name,
+			)}`,
 		);
 	}
 
-	onunload() { }
+	onunload() {}
 
 	async loadSettings() {
 		this.settings = Object.assign(
 			{},
 			DEFAULT_SETTINGS,
-			await this.loadData()
+			await this.loadData(),
 		);
 	}
 
@@ -129,7 +129,7 @@ class MarkdownExportSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.output = value;
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
 
 		new Setting(containerEl)
@@ -142,13 +142,13 @@ class MarkdownExportSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.attachment = value;
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
 
 		new Setting(containerEl)
 			.setName("Use GitHub Flavored Markdown Format")
 			.setDesc(
-				"The format of markdown is more inclined to choose Github Flavored Markdown"
+				"The format of markdown is more inclined to choose Github Flavored Markdown",
 			)
 			.addToggle((toggle) =>
 				toggle
@@ -156,13 +156,27 @@ class MarkdownExportSettingTab extends PluginSettingTab {
 					.onChange(async (value: boolean) => {
 						this.plugin.settings.GFM = value;
 						await this.plugin.saveSettings();
-					})
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Use Html tag <img /> to display image")
+			.setDesc(
+				"true default, <img /> tag will use the size specified in obsidian.",
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.displayImageAsHtml)
+					.onChange(async (value: boolean) => {
+						this.plugin.settings.displayImageAsHtml = value;
+						await this.plugin.saveSettings();
+					}),
 			);
 
 		new Setting(containerEl)
 			.setName("Encode file name")
 			.setDesc(
-				"true default, if you want to keep the original file name, set this to false"
+				"true default, if you want to keep the original file name, set this to false",
 			)
 			.addToggle((toggle) =>
 				toggle
@@ -170,7 +184,21 @@ class MarkdownExportSettingTab extends PluginSettingTab {
 					.onChange(async (value: boolean) => {
 						this.plugin.settings.fileNameEncode = value;
 						await this.plugin.saveSettings();
-					})
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Remove brackets for outgoing links")
+			.setDesc(
+				"true default, if you want to keep the brackets in links, set this to false",
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.removeOutgoingLinkBrackets)
+					.onChange(async (value: boolean) => {
+						this.plugin.settings.removeOutgoingLinkBrackets = value;
+						await this.plugin.saveSettings();
+					}),
 			);
 	}
 }


### PR DESCRIPTION
I've added two options to improve the experience of exporting markdown.

**1. displayImageAsHtml**

When this option is enabled, the <img/> tag replaces the traditional markdown image usage. The <img /> tag controls the size of the image displayed in markdown preview, in keeping with the experience in obsidian.

In obsidian:
```
![[image.png|400x300]]
```

In markdown:
```
<img src="attachment/image.png" style="width: 400px; height: 300px;" />
```


**2. removeOutgoingBrackets**

When this option is enabled,  the square brackets around the outgoing links are removed for a better look.

In obsidian:
```
Here is the [[another-note]].
```

In markdown:
```
Here is the another-note.
```