### PR TITLE
Fixed broken attachment paths within exported markup

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,11 @@ export const GFM_IMAGE_FORMAT = "![]({0})";
 
 export const OUTGOING_LINK_REGEXP = /(?<!!)\[\[(.*?)\]\]/g;
 
+export enum OUTPUT_FORMATS {
+	MD = 'Markdown',
+	HTML = 'HTML'
+}
+
 export interface MarkdownExportPluginSettings {
 	output: string;
 	attachment: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ export interface MarkdownExportPluginSettings {
 	removeOutgoingLinkBrackets: boolean;
 	includeFileName: boolean;
 	customFileName: string;
+	relAttachPath: boolean;
 }
 
 export const DEFAULT_SETTINGS: MarkdownExportPluginSettings = {
@@ -29,4 +30,5 @@ export const DEFAULT_SETTINGS: MarkdownExportPluginSettings = {
 	removeOutgoingLinkBrackets: false,
 	includeFileName: false,
 	customFileName: "",
+	relAttachPath: true,
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,13 @@ export const GFM_IMAGE_FORMAT = "![]({0})";
 
 export const OUTGOING_LINK_REGEXP = /(?<!!)\[\[(.*?)\]\]/g;
 
+export enum OUTPUT_INCLUDE_FILENAME {
+	NONE = '',
+	OUTPUT = 'OUTPUT',
+	ATTACHMENT = 'ATTACH',
+	ALL = 'OUTPUTATTACH'
+}
+
 export interface MarkdownExportPluginSettings {
 	output: string;
 	attachment: string;
@@ -16,7 +23,7 @@ export interface MarkdownExportPluginSettings {
 	GFM: boolean;
 	fileNameEncode: boolean;
 	removeOutgoingLinkBrackets: boolean;
-	includeFileName: boolean;
+	includeFileName: string;
 	customFileName: string;
 	relAttachPath: boolean;
 }
@@ -28,7 +35,7 @@ export const DEFAULT_SETTINGS: MarkdownExportPluginSettings = {
 	GFM: true,
 	fileNameEncode: true,
 	removeOutgoingLinkBrackets: false,
-	includeFileName: false,
+	includeFileName: OUTPUT_INCLUDE_FILENAME.NONE,
 	customFileName: "",
 	relAttachPath: true,
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ export interface MarkdownExportPluginSettings {
 	removeOutgoingLinkBrackets: boolean;
 	includeFileName: boolean;
 	customFileName: string;
+	customAttachPath: string;
 	relAttachPath: boolean;
 }
 
@@ -35,5 +36,6 @@ export const DEFAULT_SETTINGS: MarkdownExportPluginSettings = {
 	removeOutgoingLinkBrackets: false,
 	includeFileName: false,
 	customFileName: "",
+	customAttachPath: "",
 	relAttachPath: true,
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,13 +9,6 @@ export const GFM_IMAGE_FORMAT = "![]({0})";
 
 export const OUTGOING_LINK_REGEXP = /(?<!!)\[\[(.*?)\]\]/g;
 
-export enum OUTPUT_INCLUDE_FILENAME {
-	NONE = '',
-	OUTPUT = 'OUTPUT',
-	ATTACHMENT = 'ATTACH',
-	ALL = 'OUTPUTATTACH'
-}
-
 export interface MarkdownExportPluginSettings {
 	output: string;
 	attachment: string;
@@ -23,7 +16,7 @@ export interface MarkdownExportPluginSettings {
 	GFM: boolean;
 	fileNameEncode: boolean;
 	removeOutgoingLinkBrackets: boolean;
-	includeFileName: string;
+	includeFileName: boolean;
 	customFileName: string;
 	relAttachPath: boolean;
 }
@@ -35,7 +28,7 @@ export const DEFAULT_SETTINGS: MarkdownExportPluginSettings = {
 	GFM: true,
 	fileNameEncode: true,
 	removeOutgoingLinkBrackets: false,
-	includeFileName: OUTPUT_INCLUDE_FILENAME.NONE,
+	includeFileName: false,
 	customFileName: "",
 	relAttachPath: true,
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import {
 } from "obsidian";
 import * as path from "path";
 
-import { MarkdownExportPluginSettings, DEFAULT_SETTINGS, OUTPUT_INCLUDE_FILENAME } from "./config";
+import { MarkdownExportPluginSettings, DEFAULT_SETTINGS } from "./config";
 import { tryRun } from "./utils";
 
 export default class MarkdownExportPlugin extends Plugin {
@@ -72,17 +72,23 @@ export default class MarkdownExportPlugin extends Plugin {
 		file: TAbstractFile,
 		outputFormat: string,
 	) {
+		console.log(file)
 		// run
 		await tryRun(this, file, outputFormat);
 
-		new Notice(
-			`Exporting ${file.path} to ${path.join(
-				this.settings.output,
-				this.settings.includeFileName.includes(OUTPUT_INCLUDE_FILENAME.OUTPUT)
-					? file.name.replace(".md", "") : '',
-				file.name,
-			)}`,
-		);
+		if (file.children) {
+			new Notice(
+				`Exporting folder ${file.path} to ${path.join(this.settings.output)}`,
+			);
+		} else {
+			new Notice(
+				`Exporting ${file.path} to ${path.join(
+					this.settings.output,
+					this.settings.includeFileName ? file.name.replace(".md", "") : '',
+					file.name,
+				)}`,
+			);
+		}
 	}
 
 	onunload() {}
@@ -202,13 +208,10 @@ class MarkdownExportSettingTab extends PluginSettingTab {
 			.setDesc(
 				"Determines when a subdirectory with the exported file's name gets created",
 			)
-			.addDropdown((dropdown) =>
-				dropdown
+			.addToggle((toggle) =>
+				toggle
 					.setValue(this.plugin.settings.includeFileName)
-					.addOption(OUTPUT_INCLUDE_FILENAME.NONE, "Never")
-					.addOption(OUTPUT_INCLUDE_FILENAME.ATTACHMENT, "For Attachments")
-					.addOption(OUTPUT_INCLUDE_FILENAME.ALL, "Always")
-					.onChange(async (value) => {
+					.onChange(async (value: boolean) => {
 						this.plugin.settings.includeFileName = value;
 						await this.plugin.saveSettings();
 					}),

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import {
 	PluginSettingTab,
 	Setting,
 	TAbstractFile,
+	TFolder,
 } from "obsidian";
 import * as path from "path";
 
@@ -72,11 +73,10 @@ export default class MarkdownExportPlugin extends Plugin {
 		file: TAbstractFile,
 		outputFormat: string,
 	) {
-		console.log(file)
 		// run
 		await tryRun(this, file, outputFormat);
 
-		if (file.children) {
+		if (file instanceof TFolder) {
 			new Notice(
 				`Exporting folder ${file.path} to ${path.join(this.settings.output)}`,
 			);

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import {
 } from "obsidian";
 import * as path from "path";
 
-import { MarkdownExportPluginSettings, DEFAULT_SETTINGS } from "./config";
+import { MarkdownExportPluginSettings, DEFAULT_SETTINGS, OUTPUT_FORMATS } from "./config";
 import { tryRun } from "./utils";
 
 export default class MarkdownExportPlugin extends Plugin {
@@ -41,7 +41,7 @@ export default class MarkdownExportPlugin extends Plugin {
 			}),
 		);
 
-		for (const outputFormat of ["markdown", "HTML"]) {
+		for (const outputFormat of [OUTPUT_FORMATS.MD, OUTPUT_FORMATS.HTML]) {
 			this.addCommand({
 				id: "export-to-" + outputFormat,
 				name: `Export to ${outputFormat}`,
@@ -58,7 +58,7 @@ export default class MarkdownExportPlugin extends Plugin {
 	}
 
 	registerDirMenu(menu: Menu, file: TAbstractFile) {
-		for (const outputFormat of ["markdown", "HTML"]) {
+		for (const outputFormat of [OUTPUT_FORMATS.MD, OUTPUT_FORMATS.HTML]) {
 			const addMenuItem = (item: MenuItem) => {
 				item.setTitle(`Export to ${outputFormat}`);
 				item.onClick(async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,8 +10,8 @@ import {
 } from "obsidian";
 import * as path from "path";
 
-import { MarkdownExportPluginSettings, DEFAULT_SETTINGS } from "./config";
-import { tryCreateFolder, tryRun } from "./utils";
+import { MarkdownExportPluginSettings, DEFAULT_SETTINGS, OUTPUT_INCLUDE_FILENAME } from "./config";
+import { tryRun } from "./utils";
 
 export default class MarkdownExportPlugin extends Plugin {
 	settings: MarkdownExportPluginSettings;
@@ -78,7 +78,8 @@ export default class MarkdownExportPlugin extends Plugin {
 		new Notice(
 			`Exporting ${file.path} to ${path.join(
 				this.settings.output,
-				this.settings.includeFileName ? file.name.replace(".md", "") : '',
+				this.settings.includeFileName.includes(OUTPUT_INCLUDE_FILENAME.OUTPUT)
+					? file.name.replace(".md", "") : '',
 				file.name,
 			)}`,
 		);
@@ -197,14 +198,17 @@ class MarkdownExportSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
-			.setName("Include filename in output path")
+			.setName("Create Subdirectory")
 			.setDesc(
-				"false default, if you want to include the filename (without extension) in the output path set this to true",
+				"Determines when a subdirectory with the exported file's name gets created",
 			)
-			.addToggle((toggle) =>
-				toggle
+			.addDropdown((dropdown) =>
+				dropdown
 					.setValue(this.plugin.settings.includeFileName)
-					.onChange(async (value: boolean) => {
+					.addOption(OUTPUT_INCLUDE_FILENAME.NONE, "Never")
+					.addOption(OUTPUT_INCLUDE_FILENAME.ATTACHMENT, "For Attachments")
+					.addOption(OUTPUT_INCLUDE_FILENAME.ALL, "Always")
+					.onChange(async (value) => {
 						this.plugin.settings.includeFileName = value;
 						await this.plugin.saveSettings();
 					}),

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,25 +72,13 @@ export default class MarkdownExportPlugin extends Plugin {
 		file: TAbstractFile,
 		outputFormat: string,
 	) {
-
-		let dir = ""
-		if (this.settings.includeFileName == true) {
-			dir = file.name.replace(".md", "")
-		}
-
-		// try create attachment directory
-		await tryCreateFolder(
-			this,
-			path.join(this.settings.output, dir, this.settings.attachment),
-		);
-
 		// run
 		await tryRun(this, file, outputFormat);
 
 		new Notice(
 			`Exporting ${file.path} to ${path.join(
 				this.settings.output,
-				dir,
+				this.settings.includeFileName ? file.name.replace(".md", "") : '',
 				file.name,
 			)}`,
 		);
@@ -222,14 +210,25 @@ class MarkdownExportSettingTab extends PluginSettingTab {
 					}),
 			);
 		new Setting(containerEl)
-			.setName("Custom filename")
+			.setName("Custom Filename")
 			.setDesc("update if you want a custom filename, leave off extension")
 			.addText((text) =>
 				text
-					.setPlaceholder("Enter custom filename")
+					.setPlaceholder("index")
 					.setValue(this.plugin.settings.customFileName)
 					.onChange(async (value) => {
 						this.plugin.settings.customFileName = value;
+						await this.plugin.saveSettings();
+					}),
+			);
+		new Setting(containerEl)
+			.setName("Set Attachment Path as Relative")
+			.setDesc("If enabled, the attachment path will be relative to the output.")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.relAttachPath)
+					.onChange(async (value: boolean) => {
+						this.plugin.settings.relAttachPath = value;
 						await this.plugin.saveSettings();
 					}),
 			);

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,7 +122,7 @@ class MarkdownExportSettingTab extends PluginSettingTab {
 		containerEl.createEl("h2", { text: "Markdown Export" });
 
 		new Setting(containerEl)
-			.setName("Custom default output path")
+			.setName("Output Path")
 			.setDesc("default directory for one-click export")
 			.addText((text) =>
 				text
@@ -135,7 +135,7 @@ class MarkdownExportSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
-			.setName("Custom attachment path(optional)")
+			.setName("Attachment Path (optional)")
 			.setDesc("attachment path, relative to the output path")
 			.addText((text) =>
 				text
@@ -143,6 +143,19 @@ class MarkdownExportSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.attachment)
 					.onChange(async (value) => {
 						this.plugin.settings.attachment = value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Custom Attachment Path")
+			.setDesc("Changes an images path in an exported file, rather than use the attachment path. Only applies to unrelative attachments. Useful if your using a static site generator.")
+			.addText((text) =>
+				text
+					.setPlaceholder("Enter attachment path")
+					.setValue(this.plugin.settings.customAttachPath)
+					.onChange(async (value) => {
+						this.plugin.settings.customAttachPath = value;
 						await this.plugin.saveSettings();
 					}),
 			);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -373,13 +373,15 @@ export async function tryCopyMarkdownByRead(
 
 				const clickSubRoute = getClickSubRoute(outputSubPath);
 
-				const hashLink = path
-					.join(
-						clickSubRoute,
-						plugin.settings.attachment,
-						imageLinkMd5.concat(imageExt),
-					)
-					.replace(/\\/g, "/");
+				const hashLink = path.join(
+					clickSubRoute,
+					plugin.settings.relAttachPath ? plugin.settings.attachment : path.join(
+						plugin.settings.customAttachPath ? plugin.settings.customAttachPath : plugin.settings.attachment,
+						plugin.settings.includeFileName ? file.name.replace(".md", "") : '',
+					),
+					imageLinkMd5.concat(imageExt),
+				).replace(/\\/g, "/");
+				console.log(hashLink)
 
 				// filter markdown link eg: http://xxx.png
 				if (urlEncodedImageLink.startsWith("http")) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,7 +37,7 @@ export async function getEmbeds(markdown: string) {
 export function allMarkdownParams(
 	file: TAbstractFile,
 	out: Array<CopyMarkdownOptions>,
-	outputFormat = OUTPUT_FORMATS.MD,
+	outputFormat: string = OUTPUT_FORMATS.MD,
 	outputSubPath = ".",
 	parentPath = "",
 ): Array<CopyMarkdownOptions> {
@@ -81,7 +81,7 @@ export function allMarkdownParams(
 export async function tryRun(
 	plugin: MarkdownExportPlugin,
 	file: TAbstractFile,
-	outputFormat = OUTPUT_FORMATS.MD,
+	outputFormat: string = OUTPUT_FORMATS.MD,
 ) {
 	// recursive functions are not suitable for this case
 	// if ((<TFile>file).extension) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,8 +8,7 @@ import {
 	MARKDOWN_ATTACHMENT_URL_REGEXP,
 	EMBED_URL_REGEXP,
 	GFM_IMAGE_FORMAT,
-	OUTGOING_LINK_REGEXP,
-	OUTPUT_INCLUDE_FILENAME
+	OUTGOING_LINK_REGEXP
 } from "./config";
 import MarkdownExportPlugin from "./main";
 import markdownToHTML from "./renderer";
@@ -242,8 +241,7 @@ export async function tryCopyImage(
 					const targetPath = path
 						.join(
 							plugin.settings.relAttachPath ? plugin.settings.output : plugin.settings.attachment, 
-							plugin.settings.includeFileName
-								.includes(OUTPUT_INCLUDE_FILENAME.ATTACHMENT) ? filename.replace(".md", "") : '', 
+							plugin.settings.includeFileName ? filename.replace(".md", "") : '', 
 							plugin.settings.relAttachPath ? plugin.settings.attachment : '',
 							imageLinkMd5.concat(imageExt),
 						)
@@ -343,8 +341,7 @@ export async function tryCopyMarkdownByRead(
 					plugin,
 					path.join(
 						plugin.settings.relAttachPath ? plugin.settings.output : plugin.settings.attachment, 
-						plugin.settings.includeFileName
-							.includes(OUTPUT_INCLUDE_FILENAME.ATTACHMENT) ? file.name.replace(".md", "") : '', 
+						plugin.settings.includeFileName ? file.name.replace(".md", "") : '', 
 						plugin.settings.relAttachPath ? plugin.settings.attachment : ''
 					)
 				);
@@ -432,9 +429,11 @@ export async function tryCopyMarkdownByRead(
 
 			await tryCopyImage(plugin, file.name, file.path);
 
+			// If the user has a custom filename set, we enforce subdirectories to prevent overwriting
 			const outDir = path.join(
 				plugin.settings.output,
-				plugin.settings.includeFileName.includes(OUTPUT_INCLUDE_FILENAME.OUTPUT)
+				(plugin.settings.customFileName != '' ||
+					(plugin.settings.includeFileName && plugin.settings.relAttachPath))
 					? file.name.replace(".md", "") : '',
 				outputSubPath
 			);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -238,16 +238,11 @@ export async function tryCopyImage(
 						continue;
 					}
 
-					let dir = ""
-					if (plugin.settings.includeFileName == true) {
-						dir = filename.replace(".md", "")
-					}
-
 					const targetPath = path
 						.join(
-							plugin.settings.output,
-							dir,
-							plugin.settings.attachment,
+							plugin.settings.relAttachPath ? plugin.settings.output : plugin.settings.attachment, 
+							plugin.settings.includeFileName ? filename.replace(".md", "") : '', 
+							plugin.settings.relAttachPath ? plugin.settings.attachment : '',
 							imageLinkMd5.concat(imageExt),
 						)
 						.replace(/\\/g, "/");
@@ -341,6 +336,17 @@ export async function tryCopyMarkdownByRead(
 	try {
 		await plugin.app.vault.adapter.read(file.path).then(async (content) => {
 			const imageLinks = await getImageLinks(content);
+			if (imageLinks.length > 0) {
+				await tryCreateFolder(
+					plugin,
+					path.join(
+						plugin.settings.relAttachPath ? plugin.settings.output : plugin.settings.attachment, 
+						plugin.settings.includeFileName ? file.name.replace(".md", "") : '', 
+						plugin.settings.relAttachPath ? plugin.settings.attachment : ''
+					)
+				);
+			}
+
 			for (const index in imageLinks) {
 				const rawImageLink = imageLinks[index][0];
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -381,7 +381,6 @@ export async function tryCopyMarkdownByRead(
 					),
 					imageLinkMd5.concat(imageExt),
 				).replace(/\\/g, "/");
-				console.log(hashLink)
 
 				// filter markdown link eg: http://xxx.png
 				if (urlEncodedImageLink.startsWith("http")) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,7 @@ import {
 	EMBED_URL_REGEXP,
 	GFM_IMAGE_FORMAT,
 	OUTGOING_LINK_REGEXP,
+	OUTPUT_INCLUDE_FILENAME
 } from "./config";
 import MarkdownExportPlugin from "./main";
 import markdownToHTML from "./renderer";
@@ -241,7 +242,8 @@ export async function tryCopyImage(
 					const targetPath = path
 						.join(
 							plugin.settings.relAttachPath ? plugin.settings.output : plugin.settings.attachment, 
-							plugin.settings.includeFileName ? filename.replace(".md", "") : '', 
+							plugin.settings.includeFileName
+								.includes(OUTPUT_INCLUDE_FILENAME.ATTACHMENT) ? filename.replace(".md", "") : '', 
 							plugin.settings.relAttachPath ? plugin.settings.attachment : '',
 							imageLinkMd5.concat(imageExt),
 						)
@@ -341,7 +343,8 @@ export async function tryCopyMarkdownByRead(
 					plugin,
 					path.join(
 						plugin.settings.relAttachPath ? plugin.settings.output : plugin.settings.attachment, 
-						plugin.settings.includeFileName ? file.name.replace(".md", "") : '', 
+						plugin.settings.includeFileName
+							.includes(OUTPUT_INCLUDE_FILENAME.ATTACHMENT) ? file.name.replace(".md", "") : '', 
 						plugin.settings.relAttachPath ? plugin.settings.attachment : ''
 					)
 				);
@@ -427,14 +430,14 @@ export async function tryCopyMarkdownByRead(
 				}
 			}
 
-			let dir = ""
-			if (plugin.settings.includeFileName == true) {
-				dir = file.name.replace(".md", "")
-			}
-
 			await tryCopyImage(plugin, file.name, file.path);
 
-			const outDir = path.join(plugin.settings.output, dir, outputSubPath);
+			const outDir = path.join(
+				plugin.settings.output,
+				plugin.settings.includeFileName.includes(OUTPUT_INCLUDE_FILENAME.OUTPUT)
+					? file.name.replace(".md", "") : '',
+				outputSubPath
+			);
 
 			await tryCreateFolder(plugin, outDir);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,8 @@ import {
 	MARKDOWN_ATTACHMENT_URL_REGEXP,
 	EMBED_URL_REGEXP,
 	GFM_IMAGE_FORMAT,
-	OUTGOING_LINK_REGEXP
+	OUTGOING_LINK_REGEXP,
+	OUTPUT_FORMATS
 } from "./config";
 import MarkdownExportPlugin from "./main";
 import markdownToHTML from "./renderer";
@@ -36,7 +37,7 @@ export async function getEmbeds(markdown: string) {
 export function allMarkdownParams(
 	file: TAbstractFile,
 	out: Array<CopyMarkdownOptions>,
-	outputFormat = "markdown",
+	outputFormat = OUTPUT_FORMATS.MD,
 	outputSubPath = ".",
 	parentPath = "",
 ): Array<CopyMarkdownOptions> {
@@ -80,7 +81,7 @@ export function allMarkdownParams(
 export async function tryRun(
 	plugin: MarkdownExportPlugin,
 	file: TAbstractFile,
-	outputFormat = "markdown",
+	outputFormat = OUTPUT_FORMATS.MD,
 ) {
 	// recursive functions are not suitable for this case
 	// if ((<TFile>file).extension) {
@@ -429,7 +430,8 @@ export async function tryCopyMarkdownByRead(
 
 			await tryCopyImage(plugin, file.name, file.path);
 
-			// If the user has a custom filename set, we enforce subdirectories to prevent overwriting
+			// If the user has a custom filename set, we enforce subdirectories to 
+			// prevent rendered files from overwriting each other
 			const outDir = path.join(
 				plugin.settings.output,
 				(plugin.settings.customFileName != '' ||
@@ -441,7 +443,7 @@ export async function tryCopyMarkdownByRead(
 			await tryCreateFolder(plugin, outDir);
 
 			switch (outputFormat) {
-				case "HTML": {
+				case OUTPUT_FORMATS.HTML: {
 					let filename
 					if (plugin.settings.customFileName) {
 						filename = plugin.settings.customFileName + ".md"
@@ -460,7 +462,7 @@ export async function tryCopyMarkdownByRead(
 					await tryCreate(plugin, targetFile, html);
 					break;
 				}
-				case "markdown": {
+				case OUTPUT_FORMATS.MD: {
 					let filename
 					if (plugin.settings.customFileName) {
 						filename = plugin.settings.customFileName + ".md"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "module": "ESNext",
-    "target": "ES6",
+    "target": "ES2018",
     "allowJs": true,
     "noImplicitAny": true,
     "moduleResolution": "node",


### PR DESCRIPTION
Hey there! This is a follow-up to my last PR (#94) as I realized that attachment paths *within* the export need to follow the same logic. If the user doesn't have `relAttachPath` as `true`, we do additional checks to ensure that the attachment link points to its respective file. I've also added the option `customAttachPath` to allow for simplified attachment links within the exported markdown. Let me know if you want any changes/additional context!