### PR TITLE
fix: prevent undefined when embed content not loaded (#116)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -706,10 +706,13 @@ export async function tryCopyMarkdownByRead(
                 const embeds = await getEmbeds(content);
                 for (const index in embeds) {
                     const url = embeds[index][1];
-                    content = content.replace(
-                        embeds[index][0],
-                        embedMap.get(url)
-                    );
+                    const replacement = embedMap.get(url);
+                    if (replacement !== undefined) {
+                        content = content.replace(
+                            embeds[index][0],
+                            replacement
+                        );
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Fixes issue where embedded tables would sometimes be replaced with "undefined" during export
- Adds a check to only replace embed content when it exists in the embed map
- Preserves original `![[...]]` marker if content is not yet loaded

## Test plan
- [x] Code change follows existing patterns in the codebase
- [x] Tested with notes containing multiple embedded tables
- [x] Verified no "undefined" strings appear in exports

Fixes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced embed content replacement when copying markdown content for improved reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->