### PR TITLE
fix: add inline block embeds support to fix #114

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,8 @@ export interface MarkdownExportPluginSettings {
     relAttachPath: boolean;
     convertWikiLinksToMarkdown: boolean;
     removeYamlHeader: boolean;
+    // Block embed settings
+    inlineBlockEmbeds: boolean;
     // Text export settings
     textExportBulletPointMap: Record<number, string>;
     textExportCheckboxUnchecked: string;
@@ -50,6 +52,8 @@ export const DEFAULT_SETTINGS: MarkdownExportPluginSettings = {
     relAttachPath: true,
     convertWikiLinksToMarkdown: false,
     removeYamlHeader: false,
+    // Block embed settings
+    inlineBlockEmbeds: false,
     // Text export settings
     textExportBulletPointMap: {
         0: "●",

--- a/src/main.ts
+++ b/src/main.ts
@@ -439,6 +439,20 @@ class MarkdownExportSettingTab extends PluginSettingTab {
                     })
             );
         new Setting(containerEl)
+            .setName("Inline Block Embeds")
+            .setDesc(
+                "If enabled, block embeds like ![[#^blockid]] will be replaced with the actual block content. " +
+                "If disabled, block embeds will be preserved as-is (may not work in exported markdown)."
+            )
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(this.plugin.settings.inlineBlockEmbeds)
+                    .onChange(async (value: boolean) => {
+                        this.plugin.settings.inlineBlockEmbeds = value;
+                        await this.plugin.saveSettings();
+                    })
+            );
+        new Setting(containerEl)
             .setName("Remove YAML Metadata Header")
             .setDesc(
                 "If enabled, the YAML metadata header will be removed from embedded files when exporting."


### PR DESCRIPTION
## Summary
- Fixes issue #114 where block embeds `![[#^blockid]]` don't work after export
- Adds new setting "Inline Block Embeds" to replace block references with actual content
- Fixes execution order: process embeds before WikiLinks conversion (prevents malformed links)
- Adds `getBlockContent()` to extract block content using Obsidian Metadata API
- Adds `parseEmbedLink()` to parse file path and block reference ID
- Prevents "undefined" output when embed content is not found

## Test plan
- [x] Code change follows existing patterns in the codebase
- [x] Build succeeds without errors
- [x] Setting added to UI with proper description
- [x] Block embeds `![[#^blockid]]` are now handled correctly
- [x] When "Inline Block Embeds" is enabled, block content is extracted and inlined
- [x] When disabled, block embeds are preserved (may not work in exported markdown)
- [x] No more "undefined" output for missing embeds

Fixes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Inline Block Embeds" setting in plugin preferences to control how block embeds appear in markdown exports. When enabled, block embeds are replaced with their actual content formatted as blockquotes. When disabled, embeds are preserved as-is.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->