### PR TITLE
fix: support percentage sizes in wiki link images (#111)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 export const ATTACHMENT_URL_REGEXP =
-    /!\[\[((.*?)\.(\w+))(?:\s*\|\s*(?<width>\d+)\s*(?:[*|x]\s*(?<height>\d+))?)?\]\]/g;
+    /!\[\[((.*?)\.(\w+))(?:\s*\|\s*(?<width>\d+%?)\s*(?:[*|x]\s*(?<height>\d+%?))?)?\]\]/g;
 
 export const MARKDOWN_ATTACHMENT_URL_REGEXP = /!\[(.*?)\]\(((.*?)\.(\w+))\)/g;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -771,13 +771,18 @@ export async function tryCopyMarkdownByRead(
                 if (plugin.settings.displayImageAsHtml) {
                     const { width = null, height = null } =
                         imageLinks[index]?.groups || {};
+                    // Helper to format size value - append 'px' only if not a percentage
+                    const formatSize = (value: string | null) => {
+                        if (!value) return "";
+                        return value.includes("%") ? value : `${value}px`;
+                    };
                     const style =
                         width && height
-                            ? ` style='width: {${width}}px; height: ${height}px;'`
+                            ? ` style='width: ${formatSize(width)}; height: ${formatSize(height)};'`
                             : width
-                            ? ` style='width: ${width}px;'`
+                            ? ` style='width: ${formatSize(width)};'`
                             : height
-                            ? ` style='height: ${height}px;'`
+                            ? ` style='height: ${formatSize(height)};'`
                             : "";
 
                     content = content.replace(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image attachments now support percentage-based dimensions in addition to pixel values. Width and height can be specified with optional % suffixes.

* **Bug Fixes**
  * Improved dimension formatting to ensure consistent unit handling across different image sizing methods, automatically applying pixel units where appropriate.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->