### PR TITLE
Pipe syntax for outgoing links

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ export const EMBED_METADATA_REGEXP =
 
 export const GFM_IMAGE_FORMAT = "![]({0})";
 
-export const OUTGOING_LINK_REGEXP = /(?<!!)\[\[(.*?)\]\]/g;
+export const OUTGOING_LINK_REGEXP = /(?<!!)\[\[(?:[^|\]]*\|)?([^\]]+)\]\]/g;
 
 export enum OUTPUT_FORMATS {
     MD = "Markdown",

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ export const EMBED_METADATA_REGEXP =
 
 export const GFM_IMAGE_FORMAT = "![]({0})";
 
-export const OUTGOING_LINK_REGEXP = /(?<!!)\[\[(?:[^|\]]*\|)?([^\]]+)\]\]/g;
+export const OUTGOING_LINK_REGEXP = /(?<!!)\[\[(?:[^|\]]*\|)?(?<alias>[^\]]+)\]\]/g;
 
 export enum OUTPUT_FORMATS {
     MD = "Markdown",


### PR DESCRIPTION
Captures the alias of Obsidian links if it exists. e.g.:
`[[My note|A special note]]` becomes `A special note`, if `removeOutgoingLinkBrackets` is activated.


Tested locally on my Obsidian vault with a note containing the following types of links :
- `[[My note]]` -> `My note`
- `[[My note|A special note]]` -> `A special note`
- `[A special note](../folder/My%20note.md)` -> `[A special note](../folder/My%20note.md)`

As seen in the example, there is still a problem with Markdown-style links in the original note. The rule to handle this edge case will be quite complicated to implement, if you want links to external URLs to be correctly exported, but links to Obsidian Vault files to be handled in the same way as the first two link styles.

Proposed solutions for the last edge case : 
- [ ] add "does not handle markdown-style links" in the description of the option "Remove brackets for outgoing links"
- [ ] edit the regex to also handle markdown-style links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wiki-link pattern matching to correctly handle links with optional aliases, providing more robust support for complex link syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->