### PR TITLE
fix: remove encodeURI for image links

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -344,18 +344,18 @@ export async function tryCopyImage(
                         imageLinks[index][7 - imageLinks[index].length];
 
                     // decode and replace the relative path
-                    let imageLink = decodeURI(urlEncodedImageLink).replace(
-                        /\.\.\//g,
-                        ""
-                    );
-                    if (imageLink.contains("|")) {
-                        imageLink = imageLink.split("|")[0];
+                    let imageLink = "";
+                    try {
+                        imageLink = decodeURIComponent(urlEncodedImageLink).replace(/\.\.\//g, "");
+                    } catch (e) {
+                        console.warn(`Unable to decode URI: ${urlEncodedImageLink}`);
+                        imageLink = urlEncodedImageLink.replace(/\.\.\//g, "");
                     }
 
                     const fileName = path.parse(path.basename(imageLink)).name;
                     const imageLinkMd5 = plugin.settings.fileNameEncode
                         ? md5(imageLink)
-                        : encodeURI(fileName);
+                        : fileName;
                     const imageExt = path.extname(imageLink);
                     const ifile = plugin.app.metadataCache.getFirstLinkpathDest(
                         imageLink,
@@ -857,10 +857,13 @@ export async function tryCopyMarkdownByRead(
                     imageLinks[index][7 - imageLinks[index].length];
 
                 // decode and replace the relative path
-                let imageLink = decodeURI(urlEncodedImageLink).replace(
-                    /\.\.\//g,
-                    ""
-                );
+                let imageLink = "";
+                try {
+                    imageLink = decodeURIComponent(urlEncodedImageLink).replace(/\.\.\//g, "");
+                } catch (e) {
+                    console.warn(`Unable to decode URI: ${urlEncodedImageLink}`);
+                    imageLink = urlEncodedImageLink.replace(/\.\.\//g, "");
+                }
                 // link: https://help.obsidian.md/Linking+notes+and+files/Embedding+files#Embed+an+image+in+a+note
                 // issue: #44 -> figure checkout: ![[name|figure]]
                 if (imageLink.contains("|")) {
@@ -869,7 +872,7 @@ export async function tryCopyMarkdownByRead(
                 const fileName = path.parse(path.basename(imageLink)).name;
                 const imageLinkMd5 = plugin.settings.fileNameEncode
                     ? md5(imageLink)
-                    : encodeURI(fileName);
+                    : fileName;
                 const imageExt = path.extname(imageLink);
                 // Unify the link separator in obsidian as a forward slash instead of the default back slash in windows, so that the referenced images can be displayed properly
 


### PR DESCRIPTION
Fixes a bug where Chinese (and other non-ASCII) filenames were incorrectly encoded as URL-encoded strings (e.g., `%E6%B5%8B%E8%AF%95.png`) when exporting images with `fileNameEncode` disabled. This happened because `encodeURI()` was applied to the file name, which is unnecessary since modern file systems natively support UTF-8 filenames. Additionally, the `decodeURI` call lacked error handling, which could cause export failures when filenames contained invalid percent-encoded sequences.

## Changes

- Removed the unnecessary `encodeURI(fileName)` call in the image export logic, so Chinese filenames are written as-is to the file system.
- Added a `try...catch` block around `decodeURIComponent` to gracefully handle malformed URI sequences, logging a warning and falling back to the original link if decoding fails.

## Testing

1. In the plugin settings, disable `fileNameEncode`.
2. Insert an image with a Chinese filename (e.g., `测试.png`) into a note.
3. Export the note and verify that the exported file retains the original Chinese filename instead of being URL-encoded.
4. Test with filenames containing invalid `%` sequences to ensure no export crash occurs.

No breaking changes expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedded image link handling during export by making URL decoding more robust and using safer fallback behavior when decoding fails.
  * Fixed image path/hash generation consistency, especially when image filenames contain special characters or when filename encoding is toggled.
  * Resolved edge cases where some image references could fail to export correctly, with fallback logic preserving more links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->